### PR TITLE
Phase 1 / Slice 1: Native quickstart skeleton (#2)

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Foreground orchestrator for {@code bin/accumulo quickstart}. Boots an ephemeral
+ * {@link MiniAccumuloCluster} with quickstart defaults, waits for it to accept traffic, prints the
+ * ready banner, and blocks until SIGTERM or SIGINT - at which point a JVM shutdown hook stops the
+ * cluster and removes the temporary data directory.
+ *
+ * <p>
+ * The 30-second-per-child-JVM shutdown timeout required by the spec is enforced by
+ * {@code MiniAccumuloClusterControl.stop(...)}, which always uses
+ * {@code stopProcessesWithTimeout(..., 30, TimeUnit.SECONDS)} when terminating each service group.
+ */
+public class Quickstart {
+
+  private static final Logger log = LoggerFactory.getLogger(Quickstart.class);
+
+  private Quickstart() {}
+
+  @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "DM_EXIT", "UNENCRYPTED_SERVER_SOCKET"},
+      justification = "quickstart is a user-facing local CLI; preflight ServerSockets are bound "
+          + "and immediately closed only to test port availability")
+  public static void main(String[] args) throws Exception {
+    QuickstartConfig config = QuickstartConfig.defaults();
+
+    Map<String,Integer> portsToCheck = new LinkedHashMap<>();
+    portsToCheck.put("ZooKeeper", config.zooKeeperPort());
+    portsToCheck.put("monitor", config.monitorPort());
+    portsToCheck.put("tablet server", config.tabletServerPort());
+    portsToCheck.put("manager", config.managerPort());
+    String conflict = firstUnavailablePort(portsToCheck);
+    if (conflict != null) {
+      System.err.println(conflict);
+      System.exit(1);
+    }
+
+    Path dataDir = Files.createTempDirectory("accumulo-quickstart-");
+    MiniAccumuloConfig macConfig = config.toMiniAccumuloConfig(dataDir.toFile());
+    MiniAccumuloCluster cluster = new MiniAccumuloCluster(macConfig);
+
+    Runtime.getRuntime()
+        .addShutdownHook(new Thread(() -> shutdown(cluster, dataDir), "quickstart-shutdown"));
+
+    cluster.start();
+
+    QuickstartReadinessCheck readinessCheck =
+        new QuickstartReadinessCheck(config.readinessTimeout());
+    QuickstartReadinessCheck.Result result =
+        readinessCheck.awaitReady(cluster, "root", config.rootPassword());
+    if (!result.success()) {
+      System.err.println("Quickstart failed to become ready: " + result.detail());
+      System.exit(1);
+    }
+
+    String banner =
+        QuickstartBanner.format(new QuickstartBanner.BannerInputs(cluster.getInstanceName(),
+            "http://localhost:" + config.monitorPort(), cluster.getZooKeepers(),
+            config.rootPassword(), dataDir.toAbsolutePath().toString(), true));
+    System.out.print(banner);
+    System.out.flush();
+
+    new CountDownLatch(1).await();
+  }
+
+  /**
+   * @return null if all ports are available, otherwise a human-readable error message naming the
+   *         first conflict.
+   */
+  static String firstUnavailablePort(Map<String,Integer> ports) {
+    for (Map.Entry<String,Integer> e : ports.entrySet()) {
+      String name = e.getKey();
+      int port = e.getValue();
+      if (!isPortAvailable(port)) {
+        return "Port " + port + " (" + name + ") is already in use. "
+            + "Free the port and retry, or use a port-override flag (coming in a future release).";
+      }
+    }
+    return null;
+  }
+
+  @SuppressFBWarnings(value = "UNENCRYPTED_SERVER_SOCKET",
+      justification = "socket is bound and immediately closed only to test port availability")
+  private static boolean isPortAvailable(int port) {
+    try (ServerSocket socket = new ServerSocket()) {
+      socket.setReuseAddress(false);
+      socket.bind(new InetSocketAddress(port));
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private static void shutdown(MiniAccumuloCluster cluster, Path dataDir) {
+    try {
+      cluster.stop();
+    } catch (IOException | InterruptedException e) {
+      log.error("Error stopping Accumulo quickstart cluster", e);
+    }
+    try {
+      FileUtils.deleteDirectory(new File(dataDir.toString()));
+    } catch (IOException e) {
+      log.warn("Failed to clean up quickstart data directory {}", dataDir, e);
+    }
+  }
+}

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -55,6 +55,14 @@ public class Quickstart {
       justification = "quickstart is a user-facing local CLI; preflight ServerSockets are bound "
           + "and immediately closed only to test port availability")
   public static void main(String[] args) throws Exception {
+    // MAC's stop() lazily resolves a ServerContext, which in turn forces
+    // AccumuloVFSClassLoader's static initializer to run. That initializer registers its own JVM
+    // shutdown hook - which the JVM rejects with "Shutdown in progress" when triggered from
+    // inside our own shutdown hook. The cascading ExceptionInInitializerError aborts MAC's stop
+    // sequence before it gets to ZooKeeper, leaving an orphaned ZK child JVM. Pre-trigger the
+    // class load now so the shutdown hook is registered while the JVM is still in normal state.
+    Class.forName("org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader");
+
     QuickstartConfig config = QuickstartConfig.defaults();
 
     Map<String,Integer> portsToCheck = new LinkedHashMap<>();

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartBanner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartBanner.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import java.util.Objects;
+
+/**
+ * Pure formatting function that turns a {@link BannerInputs} value into the user-facing ready
+ * banner. No I/O, no global state - the same input always produces the same output, which makes the
+ * banner trivially testable via string equality.
+ */
+public final class QuickstartBanner {
+
+  private static final String DIVIDER =
+      "==========================================================================";
+
+  private QuickstartBanner() {}
+
+  /**
+   * Inputs to the banner formatter. {@code dataDirEphemeral} controls whether the data dir line is
+   * tagged {@code (ephemeral)} (Phase 1) or shown as a plain path (Phase 2 persistent mode).
+   */
+  public static final class BannerInputs {
+
+    private final String instanceName;
+    private final String monitorUrl;
+    private final String zooKeepers;
+    private final String rootPassword;
+    private final String dataDir;
+    private final boolean dataDirEphemeral;
+
+    public BannerInputs(String instanceName, String monitorUrl, String zooKeepers,
+        String rootPassword, String dataDir, boolean dataDirEphemeral) {
+      this.instanceName = Objects.requireNonNull(instanceName, "instanceName");
+      this.monitorUrl = Objects.requireNonNull(monitorUrl, "monitorUrl");
+      this.zooKeepers = Objects.requireNonNull(zooKeepers, "zooKeepers");
+      this.rootPassword = Objects.requireNonNull(rootPassword, "rootPassword");
+      this.dataDir = Objects.requireNonNull(dataDir, "dataDir");
+      this.dataDirEphemeral = dataDirEphemeral;
+    }
+
+    public String instanceName() {
+      return instanceName;
+    }
+
+    public String monitorUrl() {
+      return monitorUrl;
+    }
+
+    public String zooKeepers() {
+      return zooKeepers;
+    }
+
+    public String rootPassword() {
+      return rootPassword;
+    }
+
+    public String dataDir() {
+      return dataDir;
+    }
+
+    public boolean dataDirEphemeral() {
+      return dataDirEphemeral;
+    }
+  }
+
+  /**
+   * Format the ready banner. Output ends with a trailing newline so callers can write it directly
+   * to {@link System#out}.
+   */
+  public static String format(BannerInputs in) {
+    Objects.requireNonNull(in, "in");
+    String dataDirLine = in.dataDirEphemeral() ? in.dataDir() + " (ephemeral)" : in.dataDir();
+    StringBuilder sb = new StringBuilder();
+    sb.append(DIVIDER).append('\n');
+    sb.append(" Apache Accumulo Quickstart - ready").append('\n');
+    sb.append('\n');
+    sb.append("   Instance:       ").append(in.instanceName()).append('\n');
+    sb.append("   Monitor URL:    ").append(in.monitorUrl()).append('\n');
+    sb.append("   ZooKeeper:      ").append(in.zooKeepers()).append('\n');
+    sb.append("   Data dir:       ").append(dataDirLine).append('\n');
+    sb.append('\n');
+    sb.append("   Connect with the shell:").append('\n');
+    sb.append("     accumulo shell -zh ").append(in.zooKeepers()).append(" -zi ")
+        .append(in.instanceName()).append(" -u root -p ").append(in.rootPassword()).append('\n');
+    sb.append('\n');
+    sb.append("   Press Ctrl-C to stop.").append('\n');
+    sb.append(DIVIDER).append('\n');
+    return sb.toString();
+  }
+}

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Objects;
+
+import org.apache.accumulo.core.conf.Property;
+
+/**
+ * Immutable value object holding the user-facing configuration for {@link Quickstart}. Translates
+ * to a fully-realized {@link MiniAccumuloConfig} via {@link #toMiniAccumuloConfig(File)}.
+ *
+ * <p>
+ * Phase 1 / Slice 1 exposes default values only via {@link #defaults()}. Slice 2 will add CLI/env
+ * parsing that produces alternate instances of this class.
+ */
+public final class QuickstartConfig {
+
+  public static final String DEFAULT_INSTANCE_NAME = "quickstart";
+  public static final String DEFAULT_ROOT_PASSWORD = "secret";
+  public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
+  public static final int DEFAULT_MONITOR_PORT = 9995;
+  public static final int DEFAULT_MANAGER_PORT = 9999;
+  public static final int DEFAULT_TABLET_SERVER_PORT = 9997;
+  public static final int DEFAULT_NUM_TABLET_SERVERS = 1;
+  public static final int DEFAULT_NUM_SCAN_SERVERS = 0;
+  public static final int DEFAULT_NUM_COMPACTORS = 1;
+  public static final int DEFAULT_HEAP_MB = 256;
+  public static final Duration DEFAULT_READINESS_TIMEOUT = Duration.ofSeconds(60);
+
+  private final String instanceName;
+  private final String rootPassword;
+  private final int zooKeeperPort;
+  private final int monitorPort;
+  private final int managerPort;
+  private final int tabletServerPort;
+  private final int numTabletServers;
+  private final int numScanServers;
+  private final int numCompactors;
+  private final int heapMb;
+  private final Duration readinessTimeout;
+
+  public QuickstartConfig(String instanceName, String rootPassword, int zooKeeperPort,
+      int monitorPort, int managerPort, int tabletServerPort, int numTabletServers,
+      int numScanServers, int numCompactors, int heapMb, Duration readinessTimeout) {
+    Objects.requireNonNull(instanceName, "instanceName");
+    Objects.requireNonNull(rootPassword, "rootPassword");
+    Objects.requireNonNull(readinessTimeout, "readinessTimeout");
+    if (instanceName.isBlank()) {
+      throw new IllegalArgumentException("instanceName must not be blank");
+    }
+    if (rootPassword.isEmpty()) {
+      throw new IllegalArgumentException("rootPassword must not be empty");
+    }
+    requireValidPort(zooKeeperPort, "zooKeeperPort");
+    requireValidPort(monitorPort, "monitorPort");
+    requireValidPort(managerPort, "managerPort");
+    requireValidPort(tabletServerPort, "tabletServerPort");
+    if (numTabletServers < 1) {
+      throw new IllegalArgumentException("numTabletServers must be >= 1, got " + numTabletServers);
+    }
+    if (numScanServers < 0) {
+      throw new IllegalArgumentException("numScanServers must be >= 0, got " + numScanServers);
+    }
+    if (numCompactors < 1) {
+      throw new IllegalArgumentException("numCompactors must be >= 1, got " + numCompactors);
+    }
+    if (heapMb < 1) {
+      throw new IllegalArgumentException("heapMb must be >= 1, got " + heapMb);
+    }
+    if (readinessTimeout.isNegative() || readinessTimeout.isZero()) {
+      throw new IllegalArgumentException(
+          "readinessTimeout must be positive, got " + readinessTimeout);
+    }
+    this.instanceName = instanceName;
+    this.rootPassword = rootPassword;
+    this.zooKeeperPort = zooKeeperPort;
+    this.monitorPort = monitorPort;
+    this.managerPort = managerPort;
+    this.tabletServerPort = tabletServerPort;
+    this.numTabletServers = numTabletServers;
+    this.numScanServers = numScanServers;
+    this.numCompactors = numCompactors;
+    this.heapMb = heapMb;
+    this.readinessTimeout = readinessTimeout;
+  }
+
+  private static void requireValidPort(int port, String name) {
+    if (port < 1 || port > 65535) {
+      throw new IllegalArgumentException(name + " must be in [1, 65535], got " + port);
+    }
+  }
+
+  /**
+   * @return the canonical quickstart configuration: 1 manager / 1 tserver / 1 compactor / 0 scan
+   *         servers, ports 2181/9995/9997/9999, 256 MB heap, root password {@code secret}.
+   */
+  public static QuickstartConfig defaults() {
+    return new QuickstartConfig(DEFAULT_INSTANCE_NAME, DEFAULT_ROOT_PASSWORD,
+        DEFAULT_ZOOKEEPER_PORT, DEFAULT_MONITOR_PORT, DEFAULT_MANAGER_PORT,
+        DEFAULT_TABLET_SERVER_PORT, DEFAULT_NUM_TABLET_SERVERS, DEFAULT_NUM_SCAN_SERVERS,
+        DEFAULT_NUM_COMPACTORS, DEFAULT_HEAP_MB, DEFAULT_READINESS_TIMEOUT);
+  }
+
+  public String instanceName() {
+    return instanceName;
+  }
+
+  public String rootPassword() {
+    return rootPassword;
+  }
+
+  public int zooKeeperPort() {
+    return zooKeeperPort;
+  }
+
+  public int monitorPort() {
+    return monitorPort;
+  }
+
+  public int managerPort() {
+    return managerPort;
+  }
+
+  public int tabletServerPort() {
+    return tabletServerPort;
+  }
+
+  public int numTabletServers() {
+    return numTabletServers;
+  }
+
+  public int numScanServers() {
+    return numScanServers;
+  }
+
+  public int numCompactors() {
+    return numCompactors;
+  }
+
+  public int heapMb() {
+    return heapMb;
+  }
+
+  public Duration readinessTimeout() {
+    return readinessTimeout;
+  }
+
+  /**
+   * Translate this configuration into a fully-realized {@link MiniAccumuloConfig} pointed at
+   * {@code dir}. The caller is responsible for providing an empty/nonexistent directory and for the
+   * lifecycle of the resulting cluster.
+   *
+   * <p>
+   * Most settings flow through the public {@link MiniAccumuloConfig} surface; impl-only operations
+   * (per-property overrides, compactor count) drop down via {@code getImpl()}, mirroring the
+   * pattern used by {@code MiniAccumuloRunner}.
+   */
+  public MiniAccumuloConfig toMiniAccumuloConfig(File dir) {
+    Objects.requireNonNull(dir, "dir");
+    MiniAccumuloConfig cfg = new MiniAccumuloConfig(dir, rootPassword);
+    cfg.setInstanceName(instanceName);
+    cfg.setZooKeeperPort(zooKeeperPort);
+    cfg.setDefaultMemory(heapMb, MemoryUnit.MEGABYTE);
+    cfg.setNumTservers(numTabletServers);
+    cfg.setNumScanServers(numScanServers);
+
+    cfg.getImpl().setProperty(Property.MANAGER_CLIENTPORT, Integer.toString(managerPort));
+    cfg.getImpl().setProperty(Property.TSERV_CLIENTPORT, Integer.toString(tabletServerPort));
+    cfg.getImpl().setProperty(Property.MONITOR_PORT, Integer.toString(monitorPort));
+    cfg.getImpl().setNumCompactors(numCompactors);
+    return cfg;
+  }
+}

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartReadinessCheck.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartReadinessCheck.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+
+/**
+ * Polls a started {@link MiniAccumuloCluster} until it is accepting client traffic, or until the
+ * configured timeout elapses. Success means we successfully opened a client and listed tables -
+ * proof that the manager and tablet server are registered in ZooKeeper and serving the metadata
+ * table.
+ */
+public final class QuickstartReadinessCheck {
+
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
+  private final Duration timeout;
+
+  public QuickstartReadinessCheck(Duration timeout) {
+    Objects.requireNonNull(timeout, "timeout");
+    if (timeout.isNegative() || timeout.isZero()) {
+      throw new IllegalArgumentException("timeout must be positive, got " + timeout);
+    }
+    this.timeout = timeout;
+  }
+
+  /** Outcome of one readiness probe. */
+  public static final class Result {
+
+    private final boolean success;
+    private final Duration elapsed;
+    private final String detail;
+
+    public Result(boolean success, Duration elapsed, String detail) {
+      this.success = success;
+      this.elapsed = Objects.requireNonNull(elapsed, "elapsed");
+      this.detail = Objects.requireNonNull(detail, "detail");
+    }
+
+    public boolean success() {
+      return success;
+    }
+
+    public Duration elapsed() {
+      return elapsed;
+    }
+
+    public String detail() {
+      return detail;
+    }
+
+    @Override
+    public String toString() {
+      return "Result{success=" + success + ", elapsed=" + elapsed + ", detail=" + detail + "}";
+    }
+  }
+
+  /**
+   * Probe {@code cluster} repeatedly until {@link AccumuloClient#tableOperations()} succeeds or the
+   * timeout elapses. Always returns - never throws on a probe failure.
+   */
+  public Result awaitReady(MiniAccumuloCluster cluster, String user, String password) {
+    Objects.requireNonNull(cluster, "cluster");
+    Objects.requireNonNull(user, "user");
+    Objects.requireNonNull(password, "password");
+
+    long startNanos = System.nanoTime();
+    long deadlineNanos = startNanos + timeout.toNanos();
+    Throwable lastFailure = null;
+
+    while (System.nanoTime() < deadlineNanos) {
+      try (
+          AccumuloClient client = cluster.createAccumuloClient(user, new PasswordToken(password))) {
+        client.tableOperations().list();
+        return new Result(true, elapsedSince(startNanos), "cluster accepting traffic");
+      } catch (Exception e) {
+        lastFailure = e;
+      }
+      LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(POLL_INTERVAL.toMillis()));
+    }
+
+    String detail =
+        "timed out after " + timeout + (lastFailure == null ? "" : "; last error: " + lastFailure);
+    return new Result(false, elapsedSince(startNanos), detail);
+  }
+
+  private static Duration elapsedSince(long startNanos) {
+    return Duration.ofNanos(System.nanoTime() - startNanos);
+  }
+}

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/QuickstartExecutable.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/QuickstartExecutable.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.miniclusterImpl;
+
+import org.apache.accumulo.minicluster.Quickstart;
+import org.apache.accumulo.start.spi.KeywordExecutable;
+
+import com.google.auto.service.AutoService;
+
+/**
+ * Registers {@code accumulo quickstart} with the start-module command dispatcher. Listed in the
+ * CORE usage group so it surfaces under "Core Commands" in {@code accumulo --help} - reflecting its
+ * first-class status as the recommended local-evaluation entry point.
+ */
+@AutoService(KeywordExecutable.class)
+public class QuickstartExecutable implements KeywordExecutable {
+
+  @Override
+  public String keyword() {
+    return "quickstart";
+  }
+
+  @Override
+  public UsageGroup usageGroup() {
+    return UsageGroup.CORE;
+  }
+
+  @Override
+  public String description() {
+    return "Starts an ephemeral local Accumulo cluster with quickstart defaults";
+  }
+
+  @Override
+  public void execute(String[] args) throws Exception {
+    Quickstart.main(args);
+  }
+}

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartBannerTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartBannerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.accumulo.minicluster.QuickstartBanner.BannerInputs;
+import org.junit.jupiter.api.Test;
+
+public class QuickstartBannerTest {
+
+  @Test
+  public void formatEphemeralBannerExactString() {
+    BannerInputs in = new BannerInputs("quickstart", "http://localhost:9995", "localhost:2181",
+        "secret", "/tmp/accumulo-quickstart-12345", true);
+
+    String expected = String.join("\n",
+        "==========================================================================",
+        " Apache Accumulo Quickstart - ready", "", "   Instance:       quickstart",
+        "   Monitor URL:    http://localhost:9995", "   ZooKeeper:      localhost:2181",
+        "   Data dir:       /tmp/accumulo-quickstart-12345 (ephemeral)", "",
+        "   Connect with the shell:",
+        "     accumulo shell -zh localhost:2181 -zi quickstart -u root -p secret", "",
+        "   Press Ctrl-C to stop.",
+        "==========================================================================", "");
+
+    assertEquals(expected, QuickstartBanner.format(in));
+  }
+
+  @Test
+  public void persistentBannerOmitsEphemeralAnnotation() {
+    BannerInputs in = new BannerInputs("quickstart", "http://localhost:9995", "localhost:2181",
+        "secret", "/var/lib/accumulo/quickstart", false);
+
+    String banner = QuickstartBanner.format(in);
+    assertTrue(banner.contains("Data dir:       /var/lib/accumulo/quickstart\n"),
+        "persistent banner should show plain data dir without (ephemeral) tag, got:\n" + banner);
+    assertTrue(!banner.contains("(ephemeral)"),
+        "persistent banner must not contain (ephemeral), got:\n" + banner);
+  }
+
+  @Test
+  public void rejectsNullInputs() {
+    assertThrows(NullPointerException.class, () -> QuickstartBanner.format(null));
+  }
+}

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.apache.accumulo.core.conf.Property;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
+public class QuickstartConfigTest {
+
+  @TempDir
+  private Path tmp;
+
+  @Test
+  public void defaultsHoldTheCanonicalQuickstartShape() {
+    QuickstartConfig c = QuickstartConfig.defaults();
+    assertEquals("quickstart", c.instanceName());
+    assertEquals("secret", c.rootPassword());
+    assertEquals(2181, c.zooKeeperPort());
+    assertEquals(9995, c.monitorPort());
+    assertEquals(9999, c.managerPort());
+    assertEquals(9997, c.tabletServerPort());
+    assertEquals(1, c.numTabletServers());
+    assertEquals(0, c.numScanServers());
+    assertEquals(1, c.numCompactors());
+    assertEquals(256, c.heapMb());
+    assertEquals(Duration.ofSeconds(60), c.readinessTimeout());
+  }
+
+  @Test
+  public void translatesToMiniAccumuloConfigWithDefaults() {
+    File dir = tmp.resolve("mac").toFile();
+    QuickstartConfig c = QuickstartConfig.defaults();
+    MiniAccumuloConfig cfg = c.toMiniAccumuloConfig(dir);
+
+    assertEquals("quickstart", cfg.getInstanceName());
+    assertEquals("secret", cfg.getRootPassword());
+    assertEquals(dir, cfg.getDir());
+    assertEquals(2181, cfg.getZooKeeperPort());
+
+    // public getSiteConfig() only exposes user-supplied bulk site config; per-property setProperty
+    // calls land in the impl-level site map, so drop to getImpl() to inspect them
+    var siteConfig = cfg.getImpl().getSiteConfig();
+    assertEquals("9999", siteConfig.get(Property.MANAGER_CLIENTPORT.getKey()));
+    assertEquals("9997", siteConfig.get(Property.TSERV_CLIENTPORT.getKey()));
+    assertEquals("9995", siteConfig.get(Property.MONITOR_PORT.getKey()));
+
+    assertEquals(256L * 1024L * 1024L, cfg.getDefaultMemory());
+
+    assertEquals(1, cfg.getNumTservers());
+    // getNumScanServers / getNumCompactors are impl-only on 2.1
+    assertEquals(0, cfg.getImpl().getNumScanServers());
+    assertEquals(1, cfg.getImpl().getNumCompactors());
+  }
+
+  @Test
+  public void rejectsBlankInstanceName() {
+    assertThrows(IllegalArgumentException.class, () -> new QuickstartConfig("", "secret", 2181,
+        9995, 9999, 9997, 1, 0, 1, 256, Duration.ofSeconds(60)));
+  }
+
+  @Test
+  public void rejectsEmptyRootPassword() {
+    assertThrows(IllegalArgumentException.class, () -> new QuickstartConfig("quickstart", "", 2181,
+        9995, 9999, 9997, 1, 0, 1, 256, Duration.ofSeconds(60)));
+  }
+
+  @Test
+  public void rejectsZeroTabletServers() {
+    assertThrows(IllegalArgumentException.class, () -> new QuickstartConfig("quickstart", "secret",
+        2181, 9995, 9999, 9997, 0, 0, 1, 256, Duration.ofSeconds(60)));
+  }
+
+  @Test
+  public void rejectsNegativeScanServers() {
+    assertThrows(IllegalArgumentException.class, () -> new QuickstartConfig("quickstart", "secret",
+        2181, 9995, 9999, 9997, 1, -1, 1, 256, Duration.ofSeconds(60)));
+  }
+
+  @Test
+  public void rejectsOutOfRangePort() {
+    assertThrows(IllegalArgumentException.class, () -> new QuickstartConfig("quickstart", "secret",
+        70000, 9995, 9999, 9997, 1, 0, 1, 256, Duration.ofSeconds(60)));
+  }
+
+  @Test
+  public void rejectsZeroReadinessTimeout() {
+    assertThrows(IllegalArgumentException.class, () -> new QuickstartConfig("quickstart", "secret",
+        2181, 9995, 9999, 9997, 1, 0, 1, 256, Duration.ZERO));
+  }
+
+  @Test
+  public void translationProducesADirectoryThatMacWouldAccept() {
+    // Sanity check that we did not pre-create the dir or otherwise violate MAC's empty-dir guard
+    File dir = tmp.resolve("nested-empty").toFile();
+    MiniAccumuloConfig cfg = QuickstartConfig.defaults().toMiniAccumuloConfig(dir);
+    assertTrue(!cfg.getDir().exists() || cfg.getDir().list().length == 0);
+  }
+}

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartReadinessCheckTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartReadinessCheckTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
+public class QuickstartReadinessCheckTest extends WithTestNames {
+
+  private static final Logger log = LoggerFactory.getLogger(QuickstartReadinessCheckTest.class);
+
+  @TempDir
+  private static Path tempDir;
+
+  private MiniAccumuloCluster cluster;
+
+  @BeforeEach
+  public void setupTestCluster() throws IOException {
+    final Path perTestSubDir = tempDir.resolve(testName());
+    Files.deleteIfExists(perTestSubDir);
+    Files.createDirectories(perTestSubDir);
+    // Use random ports - this test exercises the readiness check, not the canonical-ports
+    // configuration. Production quickstart binds to fixed ports; tests must not, or they will
+    // collide with whatever else is on the machine.
+    cluster = new MiniAccumuloCluster(perTestSubDir.toFile(), "secret");
+  }
+
+  @AfterEach
+  public void teardownTestCluster() {
+    if (cluster != null) {
+      try {
+        cluster.stop();
+      } catch (IOException | InterruptedException e) {
+        log.warn("Failure during tear down", e);
+      }
+    }
+  }
+
+  @Test
+  public void readinessCheckSucceedsOnHealthyCluster() throws Exception {
+    cluster.start();
+    QuickstartReadinessCheck check = new QuickstartReadinessCheck(Duration.ofSeconds(60));
+    QuickstartReadinessCheck.Result result = check.awaitReady(cluster, "root", "secret");
+    assertTrue(result.success(), "expected success, got: " + result);
+    assertTrue(result.elapsed().toMillis() >= 0);
+  }
+
+  @Test
+  public void readinessCheckTimesOutOnStoppedCluster() throws Exception {
+    // Start and immediately stop so client connections will fail on the timeout path
+    cluster.start();
+    cluster.stop();
+
+    QuickstartReadinessCheck check = new QuickstartReadinessCheck(Duration.ofSeconds(2));
+    QuickstartReadinessCheck.Result result = check.awaitReady(cluster, "root", "secret");
+    assertFalse(result.success(), "expected timeout, got success");
+    assertTrue(result.detail().contains("timed out"),
+        "expected detail to mention timeout, got: " + result.detail());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `bin/accumulo quickstart` end-to-end with hardcoded defaults (1 manager / 1 tserver / 1 compactor / 0 scan servers, ports 2181/9995/9997/9999, 256 MB heap, root password `secret`, ephemeral data dir).
- Three deep modules carry the testable logic so the orchestrator stays thin: `QuickstartConfig` (defaults + translation to `MiniAccumuloConfig`), `QuickstartReadinessCheck` (polls until `tableOperations().list()` succeeds or times out), `QuickstartBanner` (pure formatter for the ready banner).
- `QuickstartExecutable` registers `quickstart` as a `KeywordExecutable` in the CORE usage group, so it surfaces under "Core Commands" in `accumulo --help` and dispatches via the existing `bin/accumulo` script with no shell-script changes.

Closes #2. Parent: #1.

## Acceptance criteria coverage

- [x] `org.apache.accumulo.minicluster.Quickstart` main class exists alongside `MiniAccumuloRunner`
- [x] `bin/accumulo quickstart` dispatches to it via the existing `bin/accumulo` script (CORE-group `KeywordExecutable`)
- [x] Cluster boots with the locked default shape (1 mgr / 1 tserver / 1 compactor / 0 scan servers / 1 GC / 1 monitor / 1 ZK)
- [x] Canonical Accumulo defaults (ZK 2181, monitor 9995, tserver 9997, manager 9999); no random ports
- [x] Per-service JVM heap defaults to 256 MB
- [x] Default root password is `secret`
- [x] `QuickstartConfig` deep module with default values only (no flag parsing yet)
- [x] `QuickstartReadinessCheck` deep module verifies cluster is accepting traffic before banner; configurable timeout (default 60s)
- [x] `QuickstartBanner` deep module is a pure function from inputs to string
- [x] Banner printed only after readiness check succeeds
- [x] Process runs in the foreground; service logs stream to stdout (MAC's default)
- [x] JVM shutdown hook calls `MiniAccumuloCluster.stop()`; MAC's `stopProcessesWithTimeout(..., 30, TimeUnit.SECONDS)` enforces the 30s-per-child-JVM requirement
- [x] Bind conflict on a default port produces a clear error and exits non-zero (preflight `ServerSocket` checks per port; failure exits 1 with the conflicting port + service name)
- [x] Unit tests for `QuickstartConfig` covering default-value behavior (9 tests)
- [x] Unit tests for `QuickstartBanner` asserting exact banner output (3 tests)
- [x] Integration test for `QuickstartReadinessCheck` against a real MAC: success path on a healthy cluster, timeout path on an unstartable configuration (2 tests)

Verified manually: clean build (`mvn -pl minicluster -am install -DskipTests`) including APILyzer; all 14 tests pass (`mvn -pl minicluster -am test`).

## Notes for reviewers

- The original PRD/issue says the orchestrator returns a `MiniAccumuloConfigImpl`; APILyzer rejects exposing impl types from the public `org.apache.accumulo.minicluster.*` API surface. Reworked to return the public `MiniAccumuloConfig` wrapper and drop to `getImpl()` only for impl-only operations (per-property `setProperty`, `setNumCompactors`) — same pattern `MiniAccumuloRunner` uses.
- Records and text blocks aren't usable in this codebase (`impsort-maven-plugin:1.13.0` predates JEP 359/378), so deep-module value types are plain final classes with explicit constructors and accessors.
- The integration test deliberately uses random ports rather than the canonical 2181/9995/9997/9999, so it doesn't collide with whatever's already on the developer's machine. Production quickstart binds to fixed ports, but tests must not.

## Test plan

- [ ] CI runs and the new tests pass on JDK 21 + 25
- [ ] Local manual run of `bin/accumulo quickstart` from an assemble tarball after this merges (orchestrator end-to-end isn't unit-tested; the deep modules are)
- [ ] Ctrl-C produces clean shutdown with no orphaned child JVMs (manual; the unit-tested deep modules don't exercise this end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)