### PR TITLE
Phase 1 / Slice 3: Docker image with localhost defaults (#4)

### DIFF
--- a/.github/workflows/docker-quickstart.yaml
+++ b/.github/workflows/docker-quickstart.yaml
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Builds the quickstart Docker image off the freshly-built tarball, boots it,
+# runs a shell command against the monitor URL until it's serving, exercises a
+# create-table / insert / scan round-trip through `accumulo shell` via
+# `docker exec`, then asserts a clean shutdown via `docker stop`.
+
+name: Docker Quickstart Smoke Test
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: 'maven'
+
+      - name: Build the quickstart image (tarball + docker build)
+        run: |
+          mvn -B -V -e -ntp "-Dstyle.color=always" \
+              -P docker-quickstart \
+              -Ddocker.image.tag=ci \
+              -DskipTests -DskipFormat \
+              clean package
+        env:
+          MAVEN_OPTS: -Djansi.force=true
+
+      - name: Boot the quickstart container
+        run: |
+          docker run -d --name accumulo-quickstart \
+            -p 2181:2181 -p 9995:9995 -p 9997:9997 -p 9999:9999 \
+            ghcr.io/zachradtka/newccumulo:ci
+          docker ps
+
+      - name: Wait for the monitor to serve
+        run: |
+          set -eux
+          # Up to 3 minutes - quickstart's readiness check itself is 60s; allow
+          # headroom for CI cold-start of six JVMs.
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:9995/ >/dev/null; then
+              echo "monitor up after ${i}s"
+              break
+            fi
+            if [[ $i -eq 90 ]]; then
+              echo "monitor did not come up; dumping container logs"
+              docker logs accumulo-quickstart || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Create table / insert row / scan via docker exec
+        run: |
+          set -eux
+          # Heredoc into accumulo shell as the unprivileged accumulo user.
+          # gosu in the entrypoint is bypassed here because docker exec runs
+          # as the image's USER (which is root - we drop in the entrypoint
+          # only, not by USER instruction). Pass -u so the shell command
+          # itself runs as the accumulo user.
+          docker exec -u accumulo accumulo-quickstart \
+            /opt/accumulo/bin/accumulo shell -u root -p secret -e "createtable smoke" \
+              2>&1 | tee /tmp/createtable.log
+          docker exec -u accumulo accumulo-quickstart \
+            /opt/accumulo/bin/accumulo shell -u root -p secret -e \
+              "insert -t smoke r1 cf1 cq1 v1" 2>&1 | tee /tmp/insert.log
+          docker exec -u accumulo accumulo-quickstart \
+            /opt/accumulo/bin/accumulo shell -u root -p secret -e "scan -t smoke" \
+              2>&1 | tee /tmp/scan.log
+          grep -q "r1 cf1:cq1" /tmp/scan.log
+
+      - name: Clean shutdown via docker stop
+        run: |
+          set -eux
+          # Default SIGTERM grace is 10s. Quickstart's shutdown hook + tini
+          # forwarding should land well inside that.
+          docker stop accumulo-quickstart
+          # Sanity: container must have exited within the grace period; if
+          # docker had to SIGKILL we'd see exit code 137.
+          exit_code=$(docker inspect -f '{{.State.ExitCode}}' accumulo-quickstart)
+          echo "container exit code: ${exit_code}"
+          test "${exit_code}" != "137"
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs accumulo-quickstart || true
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f accumulo-quickstart || true

--- a/.github/workflows/docker-quickstart.yaml
+++ b/.github/workflows/docker-quickstart.yaml
@@ -48,12 +48,22 @@ jobs:
           cache: 'maven'
 
       - name: Build the quickstart image (tarball + docker build)
+        # `verify`, not `package`: maven-assembly-plugin runs last in the
+        # package phase, so the docker steps must observe the tarball from a
+        # later phase. See the docker-quickstart profile comment in
+        # assemble/pom.xml.
+        #
+        # checkstyle/spotbugs are skipped here: this job validates the Docker
+        # image, and the QA workflow already owns static analysis. Skipping
+        # keeps the smoke test from going red on a style nit in an unrelated
+        # module.
         run: |
           mvn -B -V -e -ntp "-Dstyle.color=always" \
               -P docker-quickstart \
               -Ddocker.image.tag=ci \
               -DskipTests -DskipFormat \
-              clean package
+              -Dcheckstyle.skip=true -Dspotbugs.skip=true \
+              clean verify
         env:
           MAVEN_OPTS: -Djansi.force=true
 

--- a/.github/workflows/docker-quickstart.yaml
+++ b/.github/workflows/docker-quickstart.yaml
@@ -95,20 +95,22 @@ jobs:
       - name: Create table / insert row / scan via docker exec
         run: |
           set -eux
-          # Heredoc into accumulo shell as the unprivileged accumulo user.
-          # gosu in the entrypoint is bypassed here because docker exec runs
-          # as the image's USER (which is root - we drop in the entrypoint
-          # only, not by USER instruction). Pass -u so the shell command
-          # itself runs as the accumulo user.
-          docker exec -u accumulo accumulo-quickstart \
-            /opt/accumulo/bin/accumulo shell -u root -p secret -e "createtable smoke" \
-              2>&1 | tee /tmp/createtable.log
-          docker exec -u accumulo accumulo-quickstart \
-            /opt/accumulo/bin/accumulo shell -u root -p secret -e \
-              "insert -t smoke r1 cf1 cq1 v1" 2>&1 | tee /tmp/insert.log
-          docker exec -u accumulo accumulo-quickstart \
-            /opt/accumulo/bin/accumulo shell -u root -p secret -e "scan -t smoke" \
-              2>&1 | tee /tmp/scan.log
+          # Run accumulo shell as the unprivileged accumulo user. gosu in the
+          # entrypoint is bypassed here because docker exec runs as the image's
+          # USER (root - we drop privileges in the entrypoint only, not via a
+          # USER instruction), so pass -u to run the shell as accumulo.
+          #
+          # -zi/-zh are passed explicitly: the bundled accumulo-client.properties
+          # ships with an empty instance.name, so the shell cannot discover the
+          # instance on its own.
+          shell() {
+            docker exec -u accumulo accumulo-quickstart \
+              /opt/accumulo/bin/accumulo shell -zh localhost:2181 -zi quickstart \
+              -u root -p secret -e "$1"
+          }
+          shell "createtable smoke" 2>&1 | tee /tmp/createtable.log
+          shell "insert -t smoke r1 cf1 cq1 v1" 2>&1 | tee /tmp/insert.log
+          shell "scan -t smoke" 2>&1 | tee /tmp/scan.log
           grep -q "r1 cf1:cq1" /tmp/scan.log
 
       - name: Clean shutdown via docker stop

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -55,8 +55,8 @@ ZOOKEEPER_HOME="${ZOOKEEPER_HOME:-/path/to/zookeeper}"
 ## existing production-style classpath (no behavior change for site-installed
 ## Accumulo).
 # cmd is exported by bin/accumulo
-#shellcheck disable=SC2154
 quickstart_classpath=false
+#shellcheck disable=SC2154
 if [[ $cmd == "quickstart" ]]; then
   quickstart_classpath=true
 elif [[ $cmd == "shell" && (! -d $HADOOP_HOME || ! -d $ZOOKEEPER_HOME) ]]; then

--- a/assemble/docker/quickstart/Dockerfile
+++ b/assemble/docker/quickstart/Dockerfile
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM eclipse-temurin:17-jre-jammy
+
+# tini handles signal forwarding and zombie reaping for MAC's spawned child JVMs.
+# gosu drops root cleanly after the entrypoint chowns mounted volumes.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        tini \
+        gosu \
+        curl \
+        ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1000 accumulo \
+ && useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash accumulo
+
+# The build context is assemble/target/ (the Maven profile points here). The
+# tarball is copied in and extracted under /opt/accumulo; the top-level dir
+# inside the tarball is collapsed via --strip-components=1 so paths stay short
+# regardless of the snapshot/release version suffix.
+ARG ACCUMULO_TARBALL=accumulo-bin.tar.gz
+COPY ${ACCUMULO_TARBALL} /tmp/accumulo-bin.tar.gz
+RUN set -eux; \
+    mkdir -p /opt/accumulo; \
+    tar -xzf /tmp/accumulo-bin.tar.gz -C /opt/accumulo --strip-components=1; \
+    rm /tmp/accumulo-bin.tar.gz; \
+    chown -R accumulo:accumulo /opt/accumulo
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# /data is reserved for Phase 2 persistence support. Created and chowned now so
+# the volume permissions handshake in entrypoint.sh has a stable target when
+# callers mount a host directory. Phase 1's data dir remains the JVM's
+# ephemeral /tmp.
+RUN mkdir -p /data && chown accumulo:accumulo /data
+VOLUME ["/data"]
+
+# Bind to the wildcard so Docker's -p port-forwarded traffic (which DNATs from
+# the host port to the container's bridge interface, not its loopback) actually
+# reaches our services. ACCUMULO_BIND_HOST drives BOTH rpc.bind.addr on
+# Accumulo's services AND clientPortAddress on MAC's embedded ZooKeeper -
+# without the ZK override, ZK would still listen on loopback and a host-side
+# client could TCP-connect through docker-proxy only to be disconnected on the
+# inner forward.
+#
+# Container network-namespace isolation on bridge mode already prevents
+# accidental exposure to the host network, so binding loopback-only would just
+# break the port-forwarding use case without adding security.
+#
+# rpc.advertise.addr=localhost so when host clients ask ZK where to find a
+# tserver, they get back an address that maps through -p back into the
+# container. Compose users override to their service name on the bridge net.
+ENV ACCUMULO_BIND_HOST=0.0.0.0 \
+    ACCUMULO_ADVERTISE_HOST=localhost \
+    PATH=/opt/accumulo/bin:${PATH}
+
+EXPOSE 2181 9995 9997 9999
+
+ENTRYPOINT ["tini", "--", "/entrypoint.sh"]
+CMD ["quickstart"]

--- a/assemble/docker/quickstart/Dockerfile
+++ b/assemble/docker/quickstart/Dockerfile
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 FROM eclipse-temurin:17-jre-jammy
 

--- a/assemble/docker/quickstart/entrypoint.sh
+++ b/assemble/docker/quickstart/entrypoint.sh
@@ -23,19 +23,19 @@ set -euo pipefail
 # or already owned by accumulo - avoids a pointless chown of the declared
 # VOLUME on every container start.
 if [[ -d /data ]]; then
-    current_owner="$(stat -c '%u:%g' /data)"
-    if [[ "${current_owner}" != "1000:1000" ]]; then
-        chown accumulo:accumulo /data
-    fi
+  current_owner="$(stat -c '%u:%g' /data)"
+  if [[ ${current_owner} != "1000:1000" ]]; then
+    chown accumulo:accumulo /data
+  fi
 fi
 
 # The default CMD is `quickstart`, which we route to bin/accumulo quickstart.
 # Anything else (a literal binary path, `shell`, `info`, ...) is exec'd as-is
 # so users can `docker run ... bash` for debugging or `docker exec` an
 # `accumulo shell` against a running cluster.
-if [[ "${1:-}" == "quickstart" ]]; then
-    shift
-    exec gosu accumulo /opt/accumulo/bin/accumulo quickstart "$@"
+if [[ ${1:-} == "quickstart" ]]; then
+  shift
+  exec gosu accumulo /opt/accumulo/bin/accumulo quickstart "$@"
 fi
 
 exec gosu accumulo "$@"

--- a/assemble/docker/quickstart/entrypoint.sh
+++ b/assemble/docker/quickstart/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 set -euo pipefail
 

--- a/assemble/docker/quickstart/entrypoint.sh
+++ b/assemble/docker/quickstart/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+# When the caller mounts a host directory at /data we must reset ownership so
+# the unprivileged accumulo user can write to it. Skip when /data is unmounted
+# or already owned by accumulo - avoids a pointless chown of the declared
+# VOLUME on every container start.
+if [[ -d /data ]]; then
+    current_owner="$(stat -c '%u:%g' /data)"
+    if [[ "${current_owner}" != "1000:1000" ]]; then
+        chown accumulo:accumulo /data
+    fi
+fi
+
+# The default CMD is `quickstart`, which we route to bin/accumulo quickstart.
+# Anything else (a literal binary path, `shell`, `info`, ...) is exec'd as-is
+# so users can `docker run ... bash` for debugging or `docker exec` an
+# `accumulo shell` against a running cluster.
+if [[ "${1:-}" == "quickstart" ]]; then
+    shift
+    exec gosu accumulo /opt/accumulo/bin/accumulo quickstart "$@"
+fi
+
+exec gosu accumulo "$@"

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -673,6 +673,88 @@
   </build>
   <profiles>
     <profile>
+      <!-- Build the quickstart Docker image off the freshly-assembled bin tarball.
+           Activated via `mvn -P docker-quickstart package -DskipTests`. The image
+           tag and registry are configurable via -Ddocker.image.name / -Ddocker.image.tag.
+           Skipping docker (-Ddocker.skip=true) is useful in environments without a
+           daemon - the profile is a noop in that case. -->
+      <id>docker-quickstart</id>
+      <properties>
+        <docker.image.name>ghcr.io/zachradtka/newccumulo</docker.image.name>
+        <docker.image.tag>dev</docker.image.tag>
+        <docker.skip>false</docker.skip>
+        <docker.context.dir>${project.build.directory}/docker-context</docker.context.dir>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- Stage the Dockerfile + entrypoint + tarball in a single
+                     context dir so `docker build` sees a small, deterministic
+                     build context (no /target leftovers). -->
+                <id>stage-docker-context</id>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <outputDirectory>${docker.context.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/docker/quickstart</directory>
+                      <includes>
+                        <include>Dockerfile</include>
+                        <include>entrypoint.sh</include>
+                      </includes>
+                      <filtering>false</filtering>
+                    </resource>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-bin.tar.gz</include>
+                      </includes>
+                      <filtering>false</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>docker-build-quickstart</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <skip>${docker.skip}</skip>
+                  <executable>docker</executable>
+                  <workingDirectory>${docker.context.dir}</workingDirectory>
+                  <arguments>
+                    <argument>build</argument>
+                    <argument>--build-arg</argument>
+                    <argument>ACCUMULO_TARBALL=${project.artifactId}-${project.version}-bin.tar.gz</argument>
+                    <argument>--tag</argument>
+                    <argument>${docker.image.name}:${docker.image.tag}</argument>
+                    <argument>--tag</argument>
+                    <argument>${docker.image.name}:${project.version}</argument>
+                    <argument>.</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- attach source release when it is created by the apache-release profile -->
       <id>apache-release</id>
       <build>

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -552,6 +552,7 @@
           <artifactId>license-maven-plugin</artifactId>
           <configuration>
             <mapping>
+              <Dockerfile>SCRIPT_STYLE</Dockerfile>
               <accumulo-cluster>SCRIPT_STYLE</accumulo-cluster>
               <accumulo-service>SCRIPT_STYLE</accumulo-service>
               <accumulo-util>SCRIPT_STYLE</accumulo-util>

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -674,10 +674,18 @@
   <profiles>
     <profile>
       <!-- Build the quickstart Docker image off the freshly-assembled bin tarball.
-           Activated via `mvn -P docker-quickstart package -DskipTests`. The image
+           Activated via `mvn -P docker-quickstart verify -DskipTests`. The image
            tag and registry are configurable via -Ddocker.image.name / -Ddocker.image.tag.
            Skipping docker (-Ddocker.skip=true) is useful in environments without a
-           daemon - the profile is a noop in that case. -->
+           daemon - the profile is a noop in that case.
+
+           The staging and build executions are bound to the `verify` phase, not
+           `package`: maven-assembly-plugin (which produces the bin tarball) is the
+           last plugin in the build, so its `package`-phase execution runs after
+           every other plugin's - nothing bound to `package` can observe the
+           tarball. `verify` runs strictly after `package`, and within it
+           maven-resources-plugin precedes exec-maven-plugin in plugin order, so
+           the context is staged before `docker build` runs. -->
       <id>docker-quickstart</id>
       <properties>
         <docker.image.name>ghcr.io/zachradtka/newccumulo</docker.image.name>
@@ -699,7 +707,7 @@
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
-                <phase>package</phase>
+                <phase>verify</phase>
                 <configuration>
                   <outputDirectory>${docker.context.dir}</outputDirectory>
                   <resources>
@@ -732,7 +740,7 @@
                 <goals>
                   <goal>exec</goal>
                 </goals>
-                <phase>package</phase>
+                <phase>verify</phase>
                 <configuration>
                   <skip>${docker.skip}</skip>
                   <executable>docker</executable>

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -503,6 +503,17 @@
       <artifactId>snakeyaml</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- metrics-core is a runtime dep of org.apache.zookeeper.server.ServerMetrics, but ZK
+         3.9.5 declares it at <scope>test</scope> in its own POM (a ZK packaging bug). When
+         we pull zookeeper at provided scope, Maven drops the test-scoped transitives, so we
+         have to bundle metrics-core explicitly here. Without it ZooKeeperServerMain dies on
+         startup with NoClassDefFoundError: com/codahale/metrics/Reservoir. -->
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.2.5</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Quickstart bundle (issue #10): declared at provided scope so they
          resolve for the dependency-plugin copy-dependencies execution below
          but do NOT appear in the main lib/ output (which uses dependency:list
@@ -530,17 +541,6 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper-jute</artifactId>
       <version>${version.zookeeper}</version>
-      <scope>provided</scope>
-    </dependency>
-    <!-- metrics-core is a runtime dep of org.apache.zookeeper.server.ServerMetrics, but ZK
-         3.9.5 declares it at <scope>test</scope> in its own POM (a ZK packaging bug). When
-         we pull zookeeper at provided scope, Maven drops the test-scoped transitives, so we
-         have to bundle metrics-core explicitly here. Without it ZooKeeperServerMain dies on
-         startup with NoClassDefFoundError: com/codahale/metrics/Reservoir. -->
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>3.2.5</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -688,10 +688,10 @@
            the context is staged before `docker build` runs. -->
       <id>docker-quickstart</id>
       <properties>
+        <docker.context.dir>${project.build.directory}/docker-context</docker.context.dir>
         <docker.image.name>ghcr.io/zachradtka/newccumulo</docker.image.name>
         <docker.image.tag>dev</docker.image.tag>
         <docker.skip>false</docker.skip>
-        <docker.context.dir>${project.build.directory}/docker-context</docker.context.dir>
       </properties>
       <build>
         <plugins>

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -210,6 +210,9 @@ public class Quickstart {
     }
   }
 
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
+      justification = "zoo.cfg lives in MAC's own conf dir under a JVM-created temp directory, "
+          + "not a user-supplied path; quickstart is a user-facing local CLI")
   private static void overrideZooKeeperClientPortAddress(MiniAccumuloConfig macConfig,
       String bindAddress) throws IOException {
     File zooCfg = new File(macConfig.getImpl().getConfDir(), "zoo.cfg");
@@ -227,6 +230,9 @@ public class Quickstart {
     }
   }
 
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
+      justification = "dataDir is a JVM-created temp directory, not a user-supplied path; "
+          + "quickstart is a user-facing local CLI")
   private static void shutdown(Path dataDir) {
     // Walk our own child processes (MAC spawns one JVM per service via ProcessBuilder, so they're
     // direct children of this JVM) and SIGKILL anything still alive. In the Ctrl-C case the

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -136,8 +136,7 @@ public class Quickstart {
     try {
       neutralizeMacShutdownHook(cluster);
     } catch (ReflectiveOperationException e) {
-      log.warn("Could not neutralize MAC's auto-registered shutdown hook; " + "Ctrl-C will be slow",
-          e);
+      log.warn("Could not neutralize MAC's auto-registered shutdown hook; Ctrl-C will be slow", e);
     }
 
     // MiniAccumuloClusterImpl.start() spins up ZooKeeper, tablet servers, manager, and GC -

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -19,6 +19,8 @@
 package org.apache.accumulo.minicluster;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ProcessHandle;
 import java.net.ServerSocket;
@@ -27,6 +29,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -106,6 +109,17 @@ public class Quickstart {
     Path dataDir = Files.createTempDirectory("accumulo-quickstart-");
     MiniAccumuloConfig macConfig = config.toMiniAccumuloConfig(dataDir.toFile());
     MiniAccumuloCluster cluster = new MiniAccumuloCluster(macConfig);
+
+    // MAC's embedded ZK hardcodes clientPortAddress=127.0.0.1 in the generated zoo.cfg, which is
+    // independent of Accumulo's rpc.bind.addr - the Property only controls Accumulo's own services
+    // (manager, tserver, monitor, gc, compactor). If the user requested a non-loopback bind via
+    // ACCUMULO_BIND_HOST (the Docker entrypoint sets it to 0.0.0.0 so port-forwarded clients can
+    // reach ZK), rewrite the zoo.cfg that MAC just wrote, in place, before cluster.start() spawns
+    // the ZK subprocess. MAC writes zoo.cfg synchronously in its constructor so the file exists by
+    // the time we get here.
+    if (!config.bindAddress().isEmpty()) {
+      overrideZooKeeperClientPortAddress(macConfig, config.bindAddress());
+    }
 
     Runtime.getRuntime()
         .addShutdownHook(new Thread(() -> shutdown(dataDir), "quickstart-shutdown"));
@@ -194,6 +208,23 @@ public class Quickstart {
       return true;
     } catch (IOException e) {
       return false;
+    }
+  }
+
+  private static void overrideZooKeeperClientPortAddress(MiniAccumuloConfig macConfig,
+      String bindAddress) throws IOException {
+    File zooCfg = new File(macConfig.getImpl().getConfDir(), "zoo.cfg");
+    if (!zooCfg.exists()) {
+      log.warn("zoo.cfg not found at {}; skipping clientPortAddress override", zooCfg);
+      return;
+    }
+    Properties props = new Properties();
+    try (FileInputStream in = new FileInputStream(zooCfg)) {
+      props.load(in);
+    }
+    props.setProperty("clientPortAddress", bindAddress);
+    try (FileOutputStream out = new FileOutputStream(zooCfg)) {
+      props.store(out, null);
     }
   }
 

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -274,7 +274,7 @@ public final class QuickstartConfig {
    *
    * <p>
    * All numeric and string fields are nullable so we can tell whether the user supplied a value or
-   * accepted the default — distinction matters for {@link #ENV_ROOT_PASSWORD} precedence and for
+   * accepted the default - distinction matters for {@link #ENV_ROOT_PASSWORD} precedence and for
    * the {@code --port-base} versus per-service-port mutual-exclusion rule.
    */
   static final class Args {

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -43,6 +43,22 @@ public final class QuickstartConfig {
   /** Env var consulted for the root password when no CLI flag is supplied. */
   public static final String ENV_ROOT_PASSWORD = "ACCUMULO_ROOT_PASSWORD";
 
+  /**
+   * Env var consulted for the RPC bind address (Accumulo property {@code rpc.bind.addr}). Unset or
+   * empty means "no override" - the native CLI keeps its current binding behavior, while the Docker
+   * image's entrypoint sets this to {@code 127.0.0.1} to constrain the cluster to loopback inside
+   * the container.
+   */
+  public static final String ENV_BIND_HOST = "ACCUMULO_BIND_HOST";
+
+  /**
+   * Env var consulted for the RPC advertise address (Accumulo property {@code rpc.advertise.addr}).
+   * Unset or empty means "no override". The Docker image's entrypoint sets this to
+   * {@code localhost} so external clients connecting through 1:1 port mappings to the host can
+   * reach the cluster.
+   */
+  public static final String ENV_ADVERTISE_HOST = "ACCUMULO_ADVERTISE_HOST";
+
   public static final String DEFAULT_INSTANCE_NAME = "quickstart";
   public static final String DEFAULT_ROOT_PASSWORD = "secret";
   public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
@@ -54,6 +70,10 @@ public final class QuickstartConfig {
   public static final int DEFAULT_NUM_COMPACTORS = 1;
   public static final int DEFAULT_HEAP_MB = 256;
   public static final Duration DEFAULT_READINESS_TIMEOUT = Duration.ofSeconds(60);
+  /** Empty default means "do not override Accumulo's built-in bind behavior". */
+  public static final String DEFAULT_BIND_ADDRESS = "";
+  /** Empty default means "do not override Accumulo's built-in advertise behavior". */
+  public static final String DEFAULT_ADVERTISE_ADDRESS = "";
 
   private final String instanceName;
   private final String rootPassword;
@@ -66,13 +86,26 @@ public final class QuickstartConfig {
   private final int numCompactors;
   private final int heapMb;
   private final Duration readinessTimeout;
+  private final String bindAddress;
+  private final String advertiseAddress;
 
   public QuickstartConfig(String instanceName, String rootPassword, int zooKeeperPort,
       int monitorPort, int managerPort, int tabletServerPort, int numTabletServers,
       int numScanServers, int numCompactors, int heapMb, Duration readinessTimeout) {
+    this(instanceName, rootPassword, zooKeeperPort, monitorPort, managerPort, tabletServerPort,
+        numTabletServers, numScanServers, numCompactors, heapMb, readinessTimeout,
+        DEFAULT_BIND_ADDRESS, DEFAULT_ADVERTISE_ADDRESS);
+  }
+
+  public QuickstartConfig(String instanceName, String rootPassword, int zooKeeperPort,
+      int monitorPort, int managerPort, int tabletServerPort, int numTabletServers,
+      int numScanServers, int numCompactors, int heapMb, Duration readinessTimeout,
+      String bindAddress, String advertiseAddress) {
     Objects.requireNonNull(instanceName, "instanceName");
     Objects.requireNonNull(rootPassword, "rootPassword");
     Objects.requireNonNull(readinessTimeout, "readinessTimeout");
+    Objects.requireNonNull(bindAddress, "bindAddress");
+    Objects.requireNonNull(advertiseAddress, "advertiseAddress");
     if (instanceName.isBlank()) {
       throw new IllegalArgumentException("instanceName must not be blank");
     }
@@ -110,6 +143,8 @@ public final class QuickstartConfig {
     this.numCompactors = numCompactors;
     this.heapMb = heapMb;
     this.readinessTimeout = readinessTimeout;
+    this.bindAddress = bindAddress;
+    this.advertiseAddress = advertiseAddress;
   }
 
   private static void requireValidPort(int port, String name) {
@@ -174,6 +209,22 @@ public final class QuickstartConfig {
   }
 
   /**
+   * @return the RPC bind address to apply via Accumulo's {@code rpc.bind.addr} property, or empty
+   *         string if no override should be applied.
+   */
+  public String bindAddress() {
+    return bindAddress;
+  }
+
+  /**
+   * @return the RPC advertise address to apply via Accumulo's {@code rpc.advertise.addr} property,
+   *         or empty string if no override should be applied.
+   */
+  public String advertiseAddress() {
+    return advertiseAddress;
+  }
+
+  /**
    * Translate this configuration into a fully-realized {@link MiniAccumuloConfig} pointed at
    * {@code dir}. The caller is responsible for providing an empty/nonexistent directory and for the
    * lifecycle of the resulting cluster.
@@ -196,6 +247,16 @@ public final class QuickstartConfig {
     cfg.getImpl().setProperty(Property.TSERV_CLIENTPORT, Integer.toString(tabletServerPort));
     cfg.getImpl().setProperty(Property.MONITOR_PORT, Integer.toString(monitorPort));
     cfg.getImpl().setNumCompactors(numCompactors);
+
+    // Empty defaults mean "do not override Accumulo's built-in behavior" - the native CLI keeps
+    // working unchanged. The Docker entrypoint sets these env vars so services bind to loopback
+    // and advertise a host-reachable address through 1:1 port mappings.
+    if (!bindAddress.isEmpty()) {
+      cfg.getImpl().setProperty(Property.RPC_PROCESS_BIND_ADDRESS, bindAddress);
+    }
+    if (!advertiseAddress.isEmpty()) {
+      cfg.getImpl().setProperty(Property.RPC_PROCESS_ADVERTISE_ADDRESS, advertiseAddress);
+    }
 
     // Shorten the ZooKeeper session timeout so an interactive Ctrl-C - which sends SIGINT to the
     // whole foreground process group, killing ZK before MAC's shutdown sequence can ZooZap server
@@ -372,14 +433,26 @@ public final class QuickstartConfig {
     int numCompactors =
         parsed.numCompactors != null ? parsed.numCompactors : DEFAULT_NUM_COMPACTORS;
     int heapMb = parsed.heapMb != null ? parsed.heapMb : DEFAULT_HEAP_MB;
+    String bindAddress = resolveEnvString(env, ENV_BIND_HOST, DEFAULT_BIND_ADDRESS);
+    String advertiseAddress = resolveEnvString(env, ENV_ADVERTISE_HOST, DEFAULT_ADVERTISE_ADDRESS);
 
     try {
       return ParseResult.success(new QuickstartConfig(DEFAULT_INSTANCE_NAME, rootPassword, zkPort,
           monitorPort, managerPort, tserverPort, numTservers, numScanServers, numCompactors, heapMb,
-          DEFAULT_READINESS_TIMEOUT));
+          DEFAULT_READINESS_TIMEOUT, bindAddress, advertiseAddress));
     } catch (IllegalArgumentException ex) {
       return ParseResult.error(ex.getMessage());
     }
+  }
+
+  private static String resolveEnvString(Map<String,String> env, String key, String fallback) {
+    if (env != null) {
+      String fromEnv = env.get(key);
+      if (fromEnv != null && !fromEnv.isEmpty()) {
+        return fromEnv;
+      }
+    }
+    return fallback;
   }
 
   private static String resolveRootPassword(String cliValue, Map<String,String> env) {

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
@@ -36,7 +36,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
+@SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "HARD_CODE_PASSWORD"},
+    justification = "paths not set by user input; password literals are throwaway test fixtures, "
+        + "not real credentials")
 public class QuickstartConfigTest {
 
   @TempDir

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
@@ -338,6 +338,62 @@ public class QuickstartConfigTest {
         () -> QuickstartConfig.parse(null, Collections.emptyMap()));
   }
 
+  // ---------------------------------------------------------------------------
+  // Slice 3: bind/advertise env vars consumed by the Docker entrypoint
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void defaultsHaveNoBindOrAdvertiseOverride() {
+    QuickstartConfig c = QuickstartConfig.defaults();
+    assertEquals("", c.bindAddress());
+    assertEquals("", c.advertiseAddress());
+  }
+
+  @Test
+  public void parseReadsBindAndAdvertiseFromEnv() {
+    Map<String,String> env = new HashMap<>();
+    env.put(QuickstartConfig.ENV_BIND_HOST, "127.0.0.1");
+    env.put(QuickstartConfig.ENV_ADVERTISE_HOST, "localhost");
+    ParseResult r = parseRaw(env);
+    assertEquals(ParseResult.Kind.SUCCESS, r.kind());
+    assertEquals("127.0.0.1", r.config().bindAddress());
+    assertEquals("localhost", r.config().advertiseAddress());
+  }
+
+  @Test
+  public void parseTreatsEmptyBindAndAdvertiseEnvAsUnset() {
+    Map<String,String> env = new HashMap<>();
+    env.put(QuickstartConfig.ENV_BIND_HOST, "");
+    env.put(QuickstartConfig.ENV_ADVERTISE_HOST, "");
+    ParseResult r = parseRaw(env);
+    assertEquals(ParseResult.Kind.SUCCESS, r.kind());
+    assertEquals("", r.config().bindAddress());
+    assertEquals("", r.config().advertiseAddress());
+  }
+
+  @Test
+  public void translatesBindAndAdvertiseToMacProperties() {
+    File dir = tmp.resolve("mac-bind").toFile();
+    QuickstartConfig c = new QuickstartConfig("quickstart", "secret", 2181, 9995, 9999, 9997, 1, 0,
+        1, 256, Duration.ofSeconds(60), "127.0.0.1", "localhost");
+    MiniAccumuloConfig cfg = c.toMiniAccumuloConfig(dir);
+    var siteConfig = cfg.getImpl().getSiteConfig();
+    assertEquals("127.0.0.1", siteConfig.get(Property.RPC_PROCESS_BIND_ADDRESS.getKey()));
+    assertEquals("localhost", siteConfig.get(Property.RPC_PROCESS_ADVERTISE_ADDRESS.getKey()));
+  }
+
+  @Test
+  public void translationOmitsBindAndAdvertisePropsWhenDefaulted() {
+    File dir = tmp.resolve("mac-default-bind").toFile();
+    MiniAccumuloConfig cfg = QuickstartConfig.defaults().toMiniAccumuloConfig(dir);
+    var siteConfig = cfg.getImpl().getSiteConfig();
+    // No override means the keys are absent - Accumulo falls back to its own defaults.
+    assertTrue(!siteConfig.containsKey(Property.RPC_PROCESS_BIND_ADDRESS.getKey()),
+        () -> "rpc.bind.addr should be absent by default; got: " + siteConfig);
+    assertTrue(!siteConfig.containsKey(Property.RPC_PROCESS_ADVERTISE_ADDRESS.getKey()),
+        () -> "rpc.advertise.addr should be absent by default; got: " + siteConfig);
+  }
+
   @Test
   public void parseSliceOneNoFlagsStillWorksEndToEnd() {
     // Regression guard for the acceptance criterion: running with no flags must keep working.


### PR DESCRIPTION
Closes #4.

## Summary

- Adds `assemble/docker/quickstart/{Dockerfile,entrypoint.sh}` and a `docker-quickstart` Maven profile that stages a small docker context off the freshly-built tarball and shells `docker build` to produce `ghcr.io/zachradtka/newccumulo:dev` + `:VERSION` in one invocation.
- Adds `.github/workflows/docker-quickstart.yaml` — boots the image, polls the monitor URL, exercises a create-table / insert / scan round-trip via `docker exec`, asserts a non-137 exit on `docker stop`.
- Plumbs `ACCUMULO_BIND_HOST` and `ACCUMULO_ADVERTISE_HOST` env vars through `QuickstartConfig` to Accumulo's `rpc.bind.addr` / `rpc.advertise.addr`. Empty defaults mean "no override", so the native CLI is unchanged.
- Rewrites MAC's hardcoded `clientPortAddress` in `zoo.cfg` from `Quickstart.main` when `ACCUMULO_BIND_HOST` is set. MAC's embedded ZK has its own bind setting that's independent of Accumulo's `rpc.bind.addr` — without this override ZK still listens on container loopback only and Docker `-p` port-forwarded traffic gets disconnected on the inner forward.

## Acceptance criteria

- [x] `assemble/docker/quickstart/Dockerfile` exists, based on `eclipse-temurin:17-jre-jammy`
- [x] Image includes `tini` and `gosu`
- [x] Non-root `accumulo:accumulo` UID/GID 1000 created
- [x] Dockerfile extracts the existing assemble tarball (Maven not invoked inside `docker build`)
- [x] `assemble/docker/quickstart/entrypoint.sh` chowns `/data` only when needed, `gosu`-drops, then `exec`s the quickstart
- [x] `ENTRYPOINT ["tini", "--", "/entrypoint.sh"]`, `CMD ["quickstart"]`
- [x] `EXPOSE 2181 9995 9997 9999`
- [x] `VOLUME /data`
- [x] `rpc.advertise.addr=localhost` so host clients reach the cluster through 1:1 port mappings
- [x] `docker-quickstart` Maven profile builds tarball + image with one invocation
- [x] CI smoke test boots the image, polls the monitor, runs a shell command via `docker exec`, asserts a clean teardown

### Deviation from the issue

The issue calls for services to bind to `127.0.0.1` inside the container. This is incompatible with Docker's `-p` port forwarding, which DNATs traffic from the host port to the container's *bridge* interface — a service bound to container-loopback never receives the forwarded packets. Container network-namespace isolation on bridge mode already prevents accidental host-network exposure, so binding loopback-only would just break the port-forwarding use case without adding security. The Dockerfile sets `ACCUMULO_BIND_HOST=0.0.0.0` to bind broadly inside the container, with `rpc.advertise.addr=localhost` doing the actual user-facing addressing work.

## Manual verification

```
docker run -d --rm --name qs -p 2181:2181 -p 9995:9995 -p 9997:9997 -p 9999:9999 \
    ghcr.io/zachradtka/newccumulo:dev
# wait for ready banner, then from the host:
/path/to/accumulo/bin/accumulo shell -zh localhost:2181 -zi quickstart -u root -p secret
```

End-to-end shell round-trip from a host-side tarball succeeds; `docker stop` exits cleanly in ~1.2s.

## Test plan

- [x] Unit: full `QuickstartConfigTest` suite (37 tests) passes; full `minicluster` test suite (60 tests) passes
- [x] Local: container boots, monitor returns HTTP 200, host shell connects, create-table + insert + scan returns expected row, `docker stop` exits non-137
- [ ] CI: `docker-quickstart` workflow green on this branch

## Follow-up

The quickstart banner still prints `ZooKeeper: 127.0.0.1:2181` (and `accumulo shell -zh 127.0.0.1:2181 ...`) regardless of whether the run is native or Dockerized — `cluster.getZooKeepers()` reflects what MAC was configured with, not what the host should use. Tracked in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)