### PR TITLE
Phase 1 / Slice 4: Docker security warning, host-aware banner, and docker-compose support

### DIFF
--- a/.github/workflows/docker-quickstart.yaml
+++ b/.github/workflows/docker-quickstart.yaml
@@ -21,6 +21,11 @@
 # runs a shell command against the monitor URL until it's serving, exercises a
 # create-table / insert / scan round-trip through `accumulo shell` via
 # `docker exec`, then asserts a clean shutdown via `docker stop`.
+#
+# It then reuses the same image to check the Slice 4 behavior: the host-aware
+# security warning fires under (non-loopback advertise + default password) and
+# stays silent when the password is overridden, and a second container can
+# connect through the `accumulo` compose service name.
 
 name: Docker Quickstart Smoke Test
 
@@ -132,3 +137,98 @@ jobs:
       - name: Tear down
         if: always()
         run: docker rm -f accumulo-quickstart || true
+
+      # ----------------------------------------------------------------------
+      # Slice 4: host-aware security warning
+      #
+      # --hostname accumulo gives the container a non-loopback name it can
+      # resolve back to its own bridge IP, so ACCUMULO_ADVERTISE_HOST=accumulo
+      # is both a genuine non-loopback advertise host (which trips the warning)
+      # and reachable by the in-container readiness check (so the cluster
+      # actually reaches "ready" and prints the banner).
+      # ----------------------------------------------------------------------
+      - name: Security warning present (non-loopback advertise + default password)
+        run: |
+          set -eux
+          docker run -d --name accumulo-warn \
+            --hostname accumulo \
+            -e ACCUMULO_ADVERTISE_HOST=accumulo \
+            ghcr.io/zachradtka/newccumulo:ci
+          # Wait up to 4 minutes for the ready banner to land in the logs.
+          for i in $(seq 1 120); do
+            if docker logs accumulo-warn 2>&1 | grep -q "Quickstart - ready"; then
+              echo "banner appeared after ${i} polls"
+              break
+            fi
+            if [[ $i -eq 120 ]]; then
+              echo "ready banner never appeared; dumping logs"
+              docker logs accumulo-warn || true
+              exit 1
+            fi
+            sleep 2
+          done
+          # The warning block must be present.
+          docker logs accumulo-warn 2>&1 | grep -q "SECURITY WARNING"
+
+      - name: Tear down warning container
+        if: always()
+        run: docker rm -f accumulo-warn || true
+
+      - name: Security warning absent (root password overridden)
+        run: |
+          set -eux
+          docker run -d --name accumulo-secure \
+            --hostname accumulo \
+            -e ACCUMULO_ADVERTISE_HOST=accumulo \
+            -e ACCUMULO_ROOT_PASSWORD=ci-strong-password \
+            ghcr.io/zachradtka/newccumulo:ci
+          for i in $(seq 1 120); do
+            if docker logs accumulo-secure 2>&1 | grep -q "Quickstart - ready"; then
+              echo "banner appeared after ${i} polls"
+              break
+            fi
+            if [[ $i -eq 120 ]]; then
+              echo "ready banner never appeared; dumping logs"
+              docker logs accumulo-secure || true
+              exit 1
+            fi
+            sleep 2
+          done
+          # Overriding the password must suppress the warning even though the
+          # advertise host is non-loopback.
+          if docker logs accumulo-secure 2>&1 | grep -q "SECURITY WARNING"; then
+            echo "warning was printed despite an overridden root password"
+            docker logs accumulo-secure || true
+            exit 1
+          fi
+
+      - name: Tear down secure container
+        if: always()
+        run: docker rm -f accumulo-secure || true
+
+      # ----------------------------------------------------------------------
+      # Slice 4: docker-compose connectivity
+      #
+      # The compose `client` service connects to the cluster through the
+      # `accumulo` service name on the compose network and runs a shell
+      # round-trip. --exit-code-from client propagates the client's exit code,
+      # and --abort-on-container-exit stops the never-exiting `accumulo`
+      # service once the client is done.
+      # ----------------------------------------------------------------------
+      - name: docker-compose connectivity check
+        env:
+          ACCUMULO_IMAGE: ghcr.io/zachradtka/newccumulo:ci
+        run: |
+          set -eux
+          docker compose -f assemble/docker/quickstart/docker-compose.yml \
+            up --abort-on-container-exit --exit-code-from client
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: |
+          docker compose -f assemble/docker/quickstart/docker-compose.yml logs || true
+
+      - name: Tear down compose
+        if: always()
+        run: |
+          docker compose -f assemble/docker/quickstart/docker-compose.yml down -v || true

--- a/assemble/docker/quickstart/docker-compose.yml
+++ b/assemble/docker/quickstart/docker-compose.yml
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Example: run the Accumulo quickstart cluster and connect a second container
+# to it over the compose network.
+#
+#   docker compose -f assemble/docker/quickstart/docker-compose.yml up
+#
+# The `accumulo` service sets ACCUMULO_ADVERTISE_HOST to its own compose
+# service name, so the addresses it registers in ZooKeeper resolve for any
+# other container on the compose network. The `client` service demonstrates
+# this: it waits for the cluster, then runs a create-table / insert / scan
+# round-trip through `accumulo shell` addressed at `accumulo:2181`.
+#
+# Override the image with the ACCUMULO_IMAGE env var; it defaults to the
+# published image.
+#
+# SECURITY NOTE: ACCUMULO_ADVERTISE_HOST=accumulo makes the cluster reachable
+# by every container on this network. That is fine for a local throwaway
+# cluster, but because the root password is left at the default, the cluster's
+# startup banner prints a loud SECURITY WARNING. Set ACCUMULO_ROOT_PASSWORD on
+# both services to a strong value to secure the cluster and silence it.
+
+services:
+  accumulo:
+    image: ${ACCUMULO_IMAGE:-ghcr.io/zachradtka/newccumulo:latest}
+    # Advertise the compose service name so sibling containers can connect to
+    # the manager and tablet server at `accumulo:<port>`.
+    environment:
+      ACCUMULO_ADVERTISE_HOST: accumulo
+    # The monitor is also published to the host purely for convenience; the
+    # client below does not need it.
+    ports:
+      - "9995:9995"
+
+  client:
+    image: ${ACCUMULO_IMAGE:-ghcr.io/zachradtka/newccumulo:latest}
+    depends_on:
+      - accumulo
+    # Override the default `quickstart` command. The image entrypoint runs any
+    # non-`quickstart` command as the unprivileged `accumulo` user, so this
+    # lands as `gosu accumulo bash -c ...`. Wait for ZooKeeper to answer, then
+    # run a shell round-trip against the `accumulo` service name and assert the
+    # inserted row scans back.
+    command:
+      - bash
+      - -c
+      - |
+        set -eu
+        zk=accumulo:2181
+        shell() {
+          /opt/accumulo/bin/accumulo shell -zh "$$zk" -zi quickstart \
+            -u root -p secret -e "$$1"
+        }
+        echo "waiting for the accumulo cluster to accept connections..."
+        for i in $$(seq 1 120); do
+          if shell 'tables' >/dev/null 2>&1; then
+            echo "cluster reachable at $$zk after $${i} attempts"
+            break
+          fi
+          if [ "$$i" -eq 120 ]; then
+            echo "cluster never became reachable at $$zk" >&2
+            exit 1
+          fi
+          sleep 2
+        done
+        shell 'createtable compose_smoke'
+        shell 'insert -t compose_smoke r1 cf1 cq1 v1'
+        out=$$(shell 'scan -t compose_smoke')
+        echo "$$out"
+        echo "$$out" | grep -q 'r1 cf1:cq1' \
+          && echo "compose connectivity check PASSED"

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -171,9 +171,8 @@ public class Quickstart {
     String monitorHost = advertised ? advertiseHost : "localhost";
     String banner =
         QuickstartBanner.format(new QuickstartBanner.BannerInputs(cluster.getInstanceName(),
-            "http://" + monitorHost + ":" + config.monitorPort(), zooKeepers,
-            config.rootPassword(), dataDir.toAbsolutePath().toString(), true,
-            config.shouldWarnInsecure()));
+            "http://" + monitorHost + ":" + config.monitorPort(), zooKeepers, config.rootPassword(),
+            dataDir.toAbsolutePath().toString(), true, config.shouldWarnInsecure()));
     System.out.print(banner);
     System.out.flush();
 

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -159,10 +159,21 @@ public class Quickstart {
       System.exit(1);
     }
 
+    // The banner is read by a human on whatever host launched the cluster, so the connect strings
+    // must name an address that host can actually reach. cluster.getZooKeepers() returns MAC's
+    // in-container view (127.0.0.1) - correct for a native CLI run, wrong for a Docker/compose
+    // user. When the user set ACCUMULO_ADVERTISE_HOST, that host is by definition the address the
+    // intended client uses, so build the connect strings from it instead.
+    String advertiseHost = config.advertiseAddress();
+    boolean advertised = !advertiseHost.isEmpty();
+    String zooKeepers =
+        advertised ? advertiseHost + ":" + config.zooKeeperPort() : cluster.getZooKeepers();
+    String monitorHost = advertised ? advertiseHost : "localhost";
     String banner =
         QuickstartBanner.format(new QuickstartBanner.BannerInputs(cluster.getInstanceName(),
-            "http://localhost:" + config.monitorPort(), cluster.getZooKeepers(),
-            config.rootPassword(), dataDir.toAbsolutePath().toString(), true));
+            "http://" + monitorHost + ":" + config.monitorPort(), zooKeepers,
+            config.rootPassword(), dataDir.toAbsolutePath().toString(), true,
+            config.shouldWarnInsecure()));
     System.out.print(banner);
     System.out.flush();
 

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartBanner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartBanner.java
@@ -129,15 +129,12 @@ public final class QuickstartBanner {
     sb.append(WARNING_RULE).append('\n');
     sb.append(" !! SECURITY WARNING").append('\n');
     sb.append(" !!").append('\n');
-    sb.append(" !! This cluster advertises a non-loopback address and is still using")
-        .append('\n');
+    sb.append(" !! This cluster advertises a non-loopback address and is still using").append('\n');
     sb.append(" !! the default root password. Any machine or container that can reach")
         .append('\n');
-    sb.append(" !! it has full administrative control of the cluster and its data.")
-        .append('\n');
+    sb.append(" !! it has full administrative control of the cluster and its data.").append('\n');
     sb.append(" !!").append('\n');
-    sb.append(" !! Set ACCUMULO_ROOT_PASSWORD (or pass --root-password) to a strong")
-        .append('\n');
+    sb.append(" !! Set ACCUMULO_ROOT_PASSWORD (or pass --root-password) to a strong").append('\n');
     sb.append(" !! value before exposing this cluster.").append('\n');
     sb.append(WARNING_RULE).append('\n');
     sb.append('\n');

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartBanner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartBanner.java
@@ -30,11 +30,17 @@ public final class QuickstartBanner {
   private static final String DIVIDER =
       "==========================================================================";
 
+  /** Same width as {@link #DIVIDER}, rendered as {@code !} so the warning block reads as alarm. */
+  private static final String WARNING_RULE = "!".repeat(DIVIDER.length());
+
   private QuickstartBanner() {}
 
   /**
    * Inputs to the banner formatter. {@code dataDirEphemeral} controls whether the data dir line is
    * tagged {@code (ephemeral)} (Phase 1) or shown as a plain path (Phase 2 persistent mode).
+   * {@code insecureWarning} controls whether the loud security-warning block is rendered - the
+   * caller decides this (see {@code QuickstartConfig.shouldWarnInsecure()}); the formatter stays a
+   * pure function of its inputs and never reads config or environment itself.
    */
   public static final class BannerInputs {
 
@@ -44,15 +50,17 @@ public final class QuickstartBanner {
     private final String rootPassword;
     private final String dataDir;
     private final boolean dataDirEphemeral;
+    private final boolean insecureWarning;
 
     public BannerInputs(String instanceName, String monitorUrl, String zooKeepers,
-        String rootPassword, String dataDir, boolean dataDirEphemeral) {
+        String rootPassword, String dataDir, boolean dataDirEphemeral, boolean insecureWarning) {
       this.instanceName = Objects.requireNonNull(instanceName, "instanceName");
       this.monitorUrl = Objects.requireNonNull(monitorUrl, "monitorUrl");
       this.zooKeepers = Objects.requireNonNull(zooKeepers, "zooKeepers");
       this.rootPassword = Objects.requireNonNull(rootPassword, "rootPassword");
       this.dataDir = Objects.requireNonNull(dataDir, "dataDir");
       this.dataDirEphemeral = dataDirEphemeral;
+      this.insecureWarning = insecureWarning;
     }
 
     public String instanceName() {
@@ -78,6 +86,10 @@ public final class QuickstartBanner {
     public boolean dataDirEphemeral() {
       return dataDirEphemeral;
     }
+
+    public boolean insecureWarning() {
+      return insecureWarning;
+    }
   }
 
   /**
@@ -100,8 +112,34 @@ public final class QuickstartBanner {
     sb.append("     accumulo shell -zh ").append(in.zooKeepers()).append(" -zi ")
         .append(in.instanceName()).append(" -u root -p ").append(in.rootPassword()).append('\n');
     sb.append('\n');
+    if (in.insecureWarning()) {
+      appendInsecureWarning(sb);
+    }
     sb.append("   Press Ctrl-C to stop.").append('\n');
     sb.append(DIVIDER).append('\n');
     return sb.toString();
+  }
+
+  /**
+   * Append the loud security-warning block - rendered only when the cluster advertises a
+   * non-loopback address while still using the default root password. The block is bordered with a
+   * full-width rule of {@code !} so it is hard to miss in a wall of startup logs.
+   */
+  private static void appendInsecureWarning(StringBuilder sb) {
+    sb.append(WARNING_RULE).append('\n');
+    sb.append(" !! SECURITY WARNING").append('\n');
+    sb.append(" !!").append('\n');
+    sb.append(" !! This cluster advertises a non-loopback address and is still using")
+        .append('\n');
+    sb.append(" !! the default root password. Any machine or container that can reach")
+        .append('\n');
+    sb.append(" !! it has full administrative control of the cluster and its data.")
+        .append('\n');
+    sb.append(" !!").append('\n');
+    sb.append(" !! Set ACCUMULO_ROOT_PASSWORD (or pass --root-password) to a strong")
+        .append('\n');
+    sb.append(" !! value before exposing this cluster.").append('\n');
+    sb.append(WARNING_RULE).append('\n');
+    sb.append('\n');
   }
 }

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -229,8 +229,8 @@ public final class QuickstartConfig {
    * @return {@code true} when this cluster is reachable beyond the host's own loopback - i.e.
    *         {@link #advertiseAddress()} is set to a non-loopback value - while still using the
    *         default root password. Such a cluster is dangerously open: any other machine or
-   *         container that can resolve the advertised address has full administrative control.
-   *         The Docker image defaults the advertise host to {@code localhost}, so a plain
+   *         container that can resolve the advertised address has full administrative control. The
+   *         Docker image defaults the advertise host to {@code localhost}, so a plain
    *         {@code docker run} does not trip this; a compose service name or LAN hostname does.
    */
   public boolean shouldWarnInsecure() {

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.minicluster;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -222,6 +223,38 @@ public final class QuickstartConfig {
    */
   public String advertiseAddress() {
     return advertiseAddress;
+  }
+
+  /**
+   * @return {@code true} when this cluster is reachable beyond the host's own loopback - i.e.
+   *         {@link #advertiseAddress()} is set to a non-loopback value - while still using the
+   *         default root password. Such a cluster is dangerously open: any other machine or
+   *         container that can resolve the advertised address has full administrative control.
+   *         The Docker image defaults the advertise host to {@code localhost}, so a plain
+   *         {@code docker run} does not trip this; a compose service name or LAN hostname does.
+   */
+  public boolean shouldWarnInsecure() {
+    return isNonLoopback(advertiseAddress) && rootPassword.equals(DEFAULT_ROOT_PASSWORD);
+  }
+
+  /**
+   * @return {@code true} when {@code address} is non-empty and is not one of the loopback literals
+   *         ({@code localhost}, {@code 127.0.0.1}, {@code ::1}). A bare loopback literal means the
+   *         cluster is only reachable from the host itself; anything else means the user has
+   *         deliberately made it reachable by other machines or containers.
+   */
+  private static boolean isNonLoopback(String address) {
+    if (address.isEmpty()) {
+      return false;
+    }
+    switch (address.toLowerCase(Locale.ROOT)) {
+      case "localhost":
+      case "127.0.0.1":
+      case "::1":
+        return false;
+      default:
+        return true;
+    }
   }
 
   /**

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartBannerTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartBannerTest.java
@@ -30,7 +30,7 @@ public class QuickstartBannerTest {
   @Test
   public void formatEphemeralBannerExactString() {
     BannerInputs in = new BannerInputs("quickstart", "http://localhost:9995", "localhost:2181",
-        "secret", "/tmp/accumulo-quickstart-12345", true);
+        "secret", "/tmp/accumulo-quickstart-12345", true, false);
 
     String expected = String.join("\n",
         "==========================================================================",
@@ -48,7 +48,7 @@ public class QuickstartBannerTest {
   @Test
   public void persistentBannerOmitsEphemeralAnnotation() {
     BannerInputs in = new BannerInputs("quickstart", "http://localhost:9995", "localhost:2181",
-        "secret", "/var/lib/accumulo/quickstart", false);
+        "secret", "/var/lib/accumulo/quickstart", false, false);
 
     String banner = QuickstartBanner.format(in);
     assertTrue(banner.contains("Data dir:       /var/lib/accumulo/quickstart\n"),
@@ -60,5 +60,43 @@ public class QuickstartBannerTest {
   @Test
   public void rejectsNullInputs() {
     assertThrows(NullPointerException.class, () -> QuickstartBanner.format(null));
+  }
+
+  @Test
+  public void noSecurityWarningWhenFlagIsClear() {
+    BannerInputs in = new BannerInputs("quickstart", "http://localhost:9995", "localhost:2181",
+        "secret", "/tmp/accumulo-quickstart-12345", true, false);
+
+    String banner = QuickstartBanner.format(in);
+    assertTrue(!banner.contains("SECURITY WARNING"),
+        "banner must not contain a security warning when the flag is clear, got:\n" + banner);
+    assertTrue(!banner.contains("!!"),
+        "banner must not contain the warning rule when the flag is clear, got:\n" + banner);
+  }
+
+  @Test
+  public void securityWarningBlockExactStringWhenFlagIsSet() {
+    BannerInputs in = new BannerInputs("quickstart", "http://accumulo:9995", "accumulo:2181",
+        "secret", "/tmp/accumulo-quickstart-12345", true, true);
+
+    String expected = String.join("\n",
+        "==========================================================================",
+        " Apache Accumulo Quickstart - ready", "", "   Instance:       quickstart",
+        "   Monitor URL:    http://accumulo:9995", "   ZooKeeper:      accumulo:2181",
+        "   Data dir:       /tmp/accumulo-quickstart-12345 (ephemeral)", "",
+        "   Connect with the shell:",
+        "     accumulo shell -zh accumulo:2181 -zi quickstart -u root -p secret", "",
+        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+        " !! SECURITY WARNING", " !!",
+        " !! This cluster advertises a non-loopback address and is still using",
+        " !! the default root password. Any machine or container that can reach",
+        " !! it has full administrative control of the cluster and its data.", " !!",
+        " !! Set ACCUMULO_ROOT_PASSWORD (or pass --root-password) to a strong",
+        " !! value before exposing this cluster.",
+        "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "",
+        "   Press Ctrl-C to stop.",
+        "==========================================================================", "");
+
+    assertEquals(expected, QuickstartBanner.format(in));
   }
 }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
@@ -396,6 +396,51 @@ public class QuickstartConfigTest {
         () -> "rpc.advertise.addr should be absent by default; got: " + siteConfig);
   }
 
+  // ---------------------------------------------------------------------------
+  // Slice 4: shouldWarnInsecure() - non-loopback advertise + default password
+  // ---------------------------------------------------------------------------
+
+  private static QuickstartConfig withAdvertiseAndPassword(String advertise, String password) {
+    return new QuickstartConfig("quickstart", password, 2181, 9995, 9999, 9997, 1, 0, 1, 256,
+        Duration.ofSeconds(60), "", advertise);
+  }
+
+  @Test
+  public void warnsWhenNonLoopbackAdvertiseAndDefaultPassword() {
+    assertTrue(withAdvertiseAndPassword("accumulo", "secret").shouldWarnInsecure(),
+        "a compose service name with the default password must trip the warning");
+    assertTrue(withAdvertiseAndPassword("my-lan-host", "secret").shouldWarnInsecure(),
+        "a LAN hostname with the default password must trip the warning");
+    assertTrue(withAdvertiseAndPassword("10.0.0.5", "secret").shouldWarnInsecure(),
+        "a non-loopback IP with the default password must trip the warning");
+  }
+
+  @Test
+  public void noWarnWhenPasswordOverridden() {
+    assertTrue(!withAdvertiseAndPassword("accumulo", "changed-it").shouldWarnInsecure(),
+        "overriding the root password must suppress the warning regardless of advertise host");
+  }
+
+  @Test
+  public void noWarnWhenAdvertiseIsLoopbackOrUnset() {
+    assertTrue(!withAdvertiseAndPassword("", "secret").shouldWarnInsecure(),
+        "an unset advertise host must not trip the warning");
+    assertTrue(!withAdvertiseAndPassword("localhost", "secret").shouldWarnInsecure(),
+        "advertise=localhost must not trip the warning");
+    assertTrue(!withAdvertiseAndPassword("127.0.0.1", "secret").shouldWarnInsecure(),
+        "advertise=127.0.0.1 must not trip the warning");
+    assertTrue(!withAdvertiseAndPassword("::1", "secret").shouldWarnInsecure(),
+        "advertise=::1 must not trip the warning");
+    assertTrue(!withAdvertiseAndPassword("LOCALHOST", "secret").shouldWarnInsecure(),
+        "loopback literal matching must be case-insensitive");
+  }
+
+  @Test
+  public void defaultsDoNotWarn() {
+    assertTrue(!QuickstartConfig.defaults().shouldWarnInsecure(),
+        "the canonical defaults (no advertise override) must not trip the warning");
+  }
+
   @Test
   public void parseSliceOneNoFlagsStillWorksEndToEnd() {
     // Regression guard for the acceptance criterion: running with no flags must keep working.


### PR DESCRIPTION
## Summary

Closes #5. Closes the three gaps left after Slice 3's Docker image.

- **Security warning** — `QuickstartConfig.shouldWarnInsecure()` is true when the advertise host is non-loopback (a compose service name or LAN hostname — not `localhost`/`127.0.0.1`/`::1`) **and** the root password is still the default `secret`. `QuickstartBanner` renders a loud, `!`-bordered warning block when the flag is set. The formatter stays a pure function — the caller decides whether to warn.
- **Host-aware banner** (absorbs #15) — `Quickstart.main()` derives the banner's `ZooKeeper:` connect string and monitor URL from `ACCUMULO_ADVERTISE_HOST` when set, instead of MAC's in-container `127.0.0.1` view. Native-CLI runs (advertise unset) keep the current `localhost` form unchanged.
- **docker-compose** — `assemble/docker/quickstart/docker-compose.yml` runs an `accumulo` service plus a `client` that connects via the `accumulo` service name on the compose network and runs a create-table / insert / scan round-trip.

## Trigger rule

Warn only when the advertise host is non-loopback — not the bind host. Slice 3 makes `0.0.0.0` the default bind inside the container, so a bind-based rule would fire on every default `docker run`. The advertise host is the meaningful signal: `localhost` (default) means only the host's own loopback reaches the cluster; anything else means the user deliberately exposed it.

## Testing

- `QuickstartBannerTest` / `QuickstartConfigTest` — 46 tests pass, including exact-string coverage of the warning block and `shouldWarnInsecure()` trigger logic.
- CI `docker-quickstart.yaml` gains a compose connectivity check and two security-warning checks (present under non-loopback advertise + default password; absent when the password is overridden).
- Verified locally: image build, both warning containers, and the compose round-trip (`compose connectivity check PASSED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)