### PR TITLE
Phase 1 / Slice 5: CI build, multi-arch, and registry publishing

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,183 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Builds the quickstart image multi-arch (linux/amd64 + linux/arm64) and
+# publishes it to GHCR and Docker Hub on release tags.
+#
+# Flow:
+#   1. `smoke` runs the full Docker Quickstart Smoke Test (docker-quickstart.yaml,
+#      called as a reusable workflow). It builds a single-arch image and exercises
+#      the slice 3 + slice 4 behavior. If it fails, `publish` never runs and
+#      nothing is pushed.
+#   2. `publish` (gated on `smoke`) builds the image multi-arch through the same
+#      Maven `docker-quickstart` profile and `--push`es it to GHCR, then mirrors
+#      the manifest list to Docker Hub with `docker buildx imagetools create`.
+#
+# Triggers on `v*` tags (e.g. `v2.1.5`); the image VERSION tag is the git tag
+# with the leading `v` stripped. `workflow_dispatch` is provided so the publish
+# path can be exercised manually before a real release - it takes an explicit
+# `version` input.
+#
+# Result: `docker pull` works from either registry, on Apple Silicon or x86:
+#   ghcr.io/zachradtka/newccumulo:VERSION    ghcr.io/zachradtka/newccumulo:latest
+#   docker.io/zachradtka/newccumulo:VERSION  docker.io/zachradtka/newccumulo:latest
+#
+# ---------------------------------------------------------------------------
+# Required repository secrets
+# ---------------------------------------------------------------------------
+#   GITHUB_TOKEN       Provided automatically by GitHub Actions. The `publish`
+#                      job requests `packages: write` below so it can push to
+#                      ghcr.io/zachradtka/*. No secret to create; just ensure
+#                      the repo's Actions setting allows write access to
+#                      packages (Settings > Actions > General).
+#
+#   DOCKERHUB_USERNAME The Docker Hub account that owns the `newccumulo` repo
+#                      (Settings > Secrets and variables > Actions).
+#
+#   DOCKERHUB_TOKEN    A Docker Hub access token (NOT the account password)
+#                      with Read & Write scope, created at
+#                      https://hub.docker.com/settings/security.
+# ---------------------------------------------------------------------------
+
+name: Docker Publish
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image VERSION tag to publish (no leading v, e.g. 2.1.5-rc1).'
+        required: true
+
+env:
+  # GHCR is the canonical build target; the Docker Hub copy is mirrored from it.
+  GHCR_IMAGE: ghcr.io/zachradtka/newccumulo
+  DOCKERHUB_IMAGE: docker.io/zachradtka/newccumulo
+
+jobs:
+  # Gate: the publish job only runs if this full smoke test passes. Reuses
+  # docker-quickstart.yaml verbatim so the publish path and the per-PR CI
+  # exercise the exact same image build and checks.
+  smoke:
+    uses: ./.github/workflows/docker-quickstart.yaml
+
+  publish:
+    needs: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io/zachradtka/*
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: 'maven'
+
+      - name: Resolve image VERSION tag
+        id: meta
+        # Tag pushes: strip the leading `v` (refs/tags/v2.1.5 -> 2.1.5).
+        # Manual runs: take the operator-supplied input verbatim.
+        run: |
+          set -eux
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          if [[ -z "${version}" ]]; then
+            echo "could not resolve a VERSION tag" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      # QEMU registers binfmt handlers so the linux/arm64 layers can be built
+      # on the amd64 runner; setup-buildx-action creates a docker-container
+      # builder, which is required for multi-platform `--push` builds.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build multi-arch image and push to GHCR
+        # Same Maven `docker-quickstart` profile the smoke test uses - only the
+        # buildx knobs differ: multi-arch instead of single-arch, `--push`
+        # instead of `--load`. The profile tags the build `:latest` and
+        # `:VERSION`; buildx pushes the manifest list to both on GHCR.
+        #
+        # checkstyle/spotbugs/format are skipped: this job builds a release
+        # artifact, the QA workflow owns static analysis, and the `smoke` gate
+        # already proved the image is sound.
+        run: |
+          mvn -B -V -e -ntp "-Dstyle.color=always" \
+              -P docker-quickstart \
+              -Ddocker.image.name=${GHCR_IMAGE} \
+              -Ddocker.image.tag=latest \
+              -Ddocker.image.tag.version=${{ steps.meta.outputs.version }} \
+              -Ddocker.buildx.platforms=linux/amd64,linux/arm64 \
+              -Ddocker.buildx.output=--push \
+              -DskipTests -DskipFormat \
+              -Dcheckstyle.skip=true -Dspotbugs.skip=true \
+              clean verify
+        env:
+          MAVEN_OPTS: -Djansi.force=true
+
+      - name: Mirror manifest list to Docker Hub
+        # imagetools copies the multi-arch manifest list from GHCR to Docker Hub
+        # without rebuilding - the bytes are already in a registry, so this is a
+        # cheap cross-registry manifest copy, not a second build.
+        run: |
+          set -eux
+          version="${{ steps.meta.outputs.version }}"
+          for tag in "${version}" latest; do
+            docker buildx imagetools create \
+              --tag "${DOCKERHUB_IMAGE}:${tag}" \
+              "${GHCR_IMAGE}:${tag}"
+          done
+
+      - name: Summarize published images
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          {
+            echo "### Published multi-arch images (linux/amd64, linux/arm64)"
+            echo ""
+            echo "- \`${GHCR_IMAGE}:${version}\`"
+            echo "- \`${GHCR_IMAGE}:latest\`"
+            echo "- \`${DOCKERHUB_IMAGE}:${version}\`"
+            echo "- \`${DOCKERHUB_IMAGE}:latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-quickstart.yaml
+++ b/.github/workflows/docker-quickstart.yaml
@@ -34,6 +34,9 @@ on:
     branches: [ '*' ]
   pull_request:
     branches: [ '*' ]
+  # Exposed as a reusable workflow so docker-publish.yaml can run this exact
+  # smoke test as a gate before any image is pushed to a registry.
+  workflow_call:
 
 permissions:
   contents: read

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -698,6 +698,20 @@
            the context is staged before the buildx build runs. -->
       <id>docker-quickstart</id>
       <properties>
+        <!-- These docker.* properties must stay alphabetically ordered;
+             sortpom (verify-sorted-pom) enforces it. -->
+        <!-- buildx output mode, passed as a single buildx flag. The default,
+             the load output mode, puts the image in the local daemon so the
+             smoke test can `docker run` it; the publish workflow overrides it
+             with the push output mode. A multi-arch build cannot be loaded into
+             the daemon, so multi-platform and push always go together. -->
+        <docker.buildx.output>--load</docker.buildx.output>
+        <!-- buildx target platforms. Single-arch by default so a plain
+             `mvn -P docker-quickstart verify` yields a daemon-loadable image;
+             the publish workflow overrides this to linux/amd64,linux/arm64.
+             arm64 hosts that want a native local image can pass
+             -Ddocker.buildx.platforms=linux/arm64. -->
+        <docker.buildx.platforms>linux/amd64</docker.buildx.platforms>
         <docker.context.dir>${project.build.directory}/docker-context</docker.context.dir>
         <docker.image.name>ghcr.io/zachradtka/newccumulo</docker.image.name>
         <!-- Primary image tag. The smoke workflow overrides this to `ci`; the
@@ -707,18 +721,6 @@
              the publish workflow overrides it with the release version parsed
              from the git tag (e.g. 2.1.5). -->
         <docker.image.tag.version>${project.version}</docker.image.tag.version>
-        <!-- buildx target platforms. Single-arch by default so a plain
-             `mvn -P docker-quickstart verify` yields a daemon-loadable image;
-             the publish workflow overrides this to linux/amd64,linux/arm64.
-             arm64 hosts that want a native local image can pass
-             -Ddocker.buildx.platforms=linux/arm64. -->
-        <docker.buildx.platforms>linux/amd64</docker.buildx.platforms>
-        <!-- buildx output mode, passed as a single buildx flag. The default,
-             `load`, puts the image in the local daemon so the smoke test can
-             `docker run` it; the publish workflow overrides it with `push`. A
-             multi-arch build cannot be loaded into the daemon, so multi-platform
-             and the push output mode always go together. -->
-        <docker.buildx.output>--load</docker.buildx.output>
         <docker.skip>false</docker.skip>
       </properties>
       <build>

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -676,9 +676,18 @@
     <profile>
       <!-- Build the quickstart Docker image off the freshly-assembled bin tarball.
            Activated via `mvn -P docker-quickstart verify -DskipTests`. The image
-           tag and registry are configurable via -Ddocker.image.name / -Ddocker.image.tag.
+           name and tags are configurable via -Ddocker.image.name,
+           -Ddocker.image.tag, and -Ddocker.image.tag.version.
            Skipping docker (-Ddocker.skip=true) is useful in environments without a
            daemon - the profile is a noop in that case.
+
+           The build runs through `docker buildx`: single-arch and loaded into
+           the local daemon by default (so the smoke test can `docker run` it),
+           but the publish workflow (.github/workflows/docker-publish.yaml)
+           overrides -Ddocker.buildx.platforms and -Ddocker.buildx.output to do
+           a multi-arch push. Keeping the build here, rather than a hand-rolled
+           buildx invocation in the workflow, means the Dockerfile, build
+           context, build-arg, and tag layout are defined exactly once.
 
            The staging and build executions are bound to the `verify` phase, not
            `package`: maven-assembly-plugin (which produces the bin tarball) is the
@@ -686,12 +695,30 @@
            every other plugin's - nothing bound to `package` can observe the
            tarball. `verify` runs strictly after `package`, and within it
            maven-resources-plugin precedes exec-maven-plugin in plugin order, so
-           the context is staged before `docker build` runs. -->
+           the context is staged before the buildx build runs. -->
       <id>docker-quickstart</id>
       <properties>
         <docker.context.dir>${project.build.directory}/docker-context</docker.context.dir>
         <docker.image.name>ghcr.io/zachradtka/newccumulo</docker.image.name>
+        <!-- Primary image tag. The smoke workflow overrides this to `ci`; the
+             publish workflow overrides it to `latest`. -->
         <docker.image.tag>dev</docker.image.tag>
+        <!-- Version-pinned image tag. Defaults to the Maven project version;
+             the publish workflow overrides it with the release version parsed
+             from the git tag (e.g. 2.1.5). -->
+        <docker.image.tag.version>${project.version}</docker.image.tag.version>
+        <!-- buildx target platforms. Single-arch by default so a plain
+             `mvn -P docker-quickstart verify` yields a daemon-loadable image;
+             the publish workflow overrides this to linux/amd64,linux/arm64.
+             arm64 hosts that want a native local image can pass
+             -Ddocker.buildx.platforms=linux/arm64. -->
+        <docker.buildx.platforms>linux/amd64</docker.buildx.platforms>
+        <!-- buildx output mode, passed as a single buildx flag. The default,
+             `load`, puts the image in the local daemon so the smoke test can
+             `docker run` it; the publish workflow overrides it with `push`. A
+             multi-arch build cannot be loaded into the daemon, so multi-platform
+             and the push output mode always go together. -->
+        <docker.buildx.output>--load</docker.buildx.output>
         <docker.skip>false</docker.skip>
       </properties>
       <build>
@@ -747,13 +774,17 @@
                   <executable>docker</executable>
                   <workingDirectory>${docker.context.dir}</workingDirectory>
                   <arguments>
+                    <argument>buildx</argument>
                     <argument>build</argument>
+                    <argument>--platform</argument>
+                    <argument>${docker.buildx.platforms}</argument>
+                    <argument>${docker.buildx.output}</argument>
                     <argument>--build-arg</argument>
                     <argument>ACCUMULO_TARBALL=${project.artifactId}-${project.version}-bin.tar.gz</argument>
                     <argument>--tag</argument>
                     <argument>${docker.image.name}:${docker.image.tag}</argument>
                     <argument>--tag</argument>
-                    <argument>${docker.image.name}:${project.version}</argument>
+                    <argument>${docker.image.name}:${docker.image.tag.version}</argument>
                     <argument>.</argument>
                   </arguments>
                 </configuration>


### PR DESCRIPTION
## Summary

Implements **Phase 1 / Slice 5** (#6): a release workflow that builds the
quickstart image multi-arch (`linux/amd64` + `linux/arm64`) and publishes it to
**GHCR** and **Docker Hub** on `v*` tags, gated on the existing smoke test.

Pushing a tag like `v2.1.5` produces, all multi-arch:

- `ghcr.io/zachradtka/newccumulo:2.1.5` + `:latest`
- `docker.io/zachradtka/newccumulo:2.1.5` + `:latest`

## What changed

- **`assemble/pom.xml`** — the `docker-quickstart` profile now builds through
  `docker buildx`. Four knobs were added/generalized — `docker.image.tag.version`,
  `docker.buildx.platforms`, `docker.buildx.output` — with defaults that preserve
  the existing single-arch, daemon-loaded smoke behavior. The publish workflow
  overrides them for a multi-arch push, so the Dockerfile, build context,
  build-arg, and tag layout stay defined **exactly once**.
- **`.github/workflows/docker-quickstart.yaml`** — gains a `workflow_call`
  trigger so the slice 3+4 smoke test is reused verbatim as a publish gate.
- **`.github/workflows/docker-publish.yaml`** — new workflow. Triggers on `v*`
  tags (and `workflow_dispatch` for manual runs). The `smoke` job calls the
  reusable smoke workflow; **a failed smoke test publishes nothing**. The
  `publish` job builds multi-arch through the Maven profile, pushes to GHCR,
  then mirrors the manifest list to Docker Hub with `docker buildx imagetools
  create` (a cross-registry manifest copy — no rebuild).

## ⚙️ Required setup before the first release

The workflow is inert until a `v*` tag is pushed. Before that, configure:

**1. GHCR — no secret needed.** Publishing uses the built-in `GITHUB_TOKEN`;
the `publish` job already requests `packages: write`. Just confirm
**Settings → Actions → General → Workflow permissions** allows write access.
After the first publish, the new package defaults to **private** — set it public
under the package's settings if you want anonymous `docker pull`.

**2. Docker Hub — two repository secrets.** Under
**Settings → Secrets and variables → Actions**, add:
| Secret | Value |
|---|---|
| `DOCKERHUB_USERNAME` | The Docker Hub account owning the `newccumulo` repo |
| `DOCKERHUB_TOKEN` | A Docker Hub **access token** (not the password) with Read & Write scope, from https://hub.docker.com/settings/security |

Create the `zachradtka/newccumulo` repository on Docker Hub first (the push
won't auto-create it).

**3. To release:** `git tag v2.1.5 && git push origin v2.1.5`. The image
`VERSION` tag is the git tag minus the leading `v`. To rehearse without a real
tag, run the workflow manually via **Actions → Docker Publish → Run workflow**
and supply a `version` input.

## 📄 Registry "how to use" docs

**Not in this PR — and not automatic.** Neither registry pulls usage docs from
the image:

- **GHCR** links the package to this GitHub repo, so the package page shows a
  "linked repository" pointing at the repo README — but only once you connect
  the package to the repo in its settings.
- **Docker Hub** has a repo "Overview" (a README), but `docker push` never
  updates it. Populating it requires an extra workflow step (e.g. the
  `peter-evans/dockerhub-description` action pushing a Markdown file).

Per #6/#5, registry-facing usage docs land in **Slice 6 (#7)**. Happy to add a
Docker Hub description step + a short usage doc there, or fold it in here if you
prefer.

## Testing

- `docker-quickstart` profile verified locally: `mvn -P docker-quickstart
  -Ddocker.image.tag=ci ... clean verify` builds and loads a runnable
  single-arch image through the new `buildx` path.
- The multi-arch publish path can only be exercised on GitHub Actions (needs the
  secrets above + a tag or manual dispatch).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
