### PR TITLE
Shared git pre-commit hook to auto-format staged Java sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ waiting for the tests to run.
 
 This command produces `assemble/target/accumulo-<version>-bin.tar.gz`
 
+### Git pre-commit hook
+
+Any Maven build of a clone installs a git `pre-commit` hook
+(`src/build/hooks/pre-commit`) into `.git/hooks/` automatically; no manual
+setup is needed. On each commit the hook auto-formats the staged Java sources
+with the project's `formatter-maven-plugin` and `impsort-maven-plugin`
+configuration, so commits always satisfy the CI `fastbuild` format gate.
+
+The hook is a no-op for commits that touch no Java files. Note that it formats
+every Java source in the Maven module(s) containing staged files; for a file
+with both staged and unstaged changes it formats the file on disk but does not
+re-stage it (to avoid silently committing the unstaged hunks). To commit
+without running the hook, use `git commit --no-verify`.
+
 ## Contributing
 
 Contributions are welcome to all Apache Accumulo repositories.

--- a/pom.xml
+++ b/pom.xml
@@ -1635,6 +1635,42 @@ under the License.
       </build>
     </profile>
     <profile>
+      <!-- Installs the version-controlled git hooks in src/build/hooks/ into
+           this clone's .git/hooks on any Maven build. Activated only when a
+           .git directory is present, so it is a no-op for source-tarball
+           builds; not inherited, so it runs once at the reactor root. -->
+      <id>install-git-hooks</id>
+      <activation>
+        <file>
+          <exists>.git</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.rudikershaw.gitbuildhook</groupId>
+            <artifactId>git-build-hook-maven-plugin</artifactId>
+            <version>3.6.0</version>
+            <inherited>false</inherited>
+            <configuration>
+              <installHooks>
+                <pre-commit>src/build/hooks/pre-commit</pre-commit>
+              </installHooks>
+            </configuration>
+            <executions>
+              <execution>
+                <id>install-git-hooks</id>
+                <goals>
+                  <goal>install</goal>
+                </goals>
+                <phase>initialize</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- Minimal testing profile. (a.k.a. SunnyDay) -->
       <id>sunny</id>
       <properties>

--- a/src/build/hooks/pre-commit
+++ b/src/build/hooks/pre-commit
@@ -1,0 +1,104 @@
+#! /usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Auto-format staged Java sources with the project's formatter-maven-plugin and
+# impsort-maven-plugin configuration, so every commit already satisfies the CI
+# 'fastbuild' format gate. Bypass with: git commit --no-verify
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root" || exit 1
+
+# Staged Java files (added/copied/modified). Nothing to do for non-Java commits.
+mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACM -- '*.java')
+if [[ ${#staged[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Maven is required to format. Warn but do not block the commit if it is
+# missing -- CI still enforces the format gate as a backstop.
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "pre-commit: 'mvn' not found on PATH; skipping Java auto-format." >&2
+  echo "pre-commit: install Maven, or use 'git commit --no-verify' to bypass." >&2
+  exit 0
+fi
+
+# Files with both staged and unstaged changes are partially staged. Formatting
+# rewrites the whole file, so re-staging one would also stage its unstaged
+# hunks. Format those on disk but leave re-staging to the author.
+mapfile -t unstaged < <(git diff --name-only -- '*.java')
+
+is_partially_staged() {
+  local candidate=$1 other
+  [[ ${#unstaged[@]} -eq 0 ]] && return 1
+  for other in "${unstaged[@]}"; do
+    [[ $other == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+# Nearest ancestor directory containing a pom.xml -- the Maven module owning a
+# given file. Used to scope the format run with -pl so commits stay quick.
+module_of() {
+  local dir
+  dir=$(dirname "$1")
+  while [[ $dir != "." && $dir != "/" ]]; do
+    if [[ -f $dir/pom.xml ]]; then
+      echo "$dir"
+      return
+    fi
+    dir=$(dirname "$dir")
+  done
+  echo "."
+}
+
+fully_staged=()
+partial=()
+modules=()
+for file in "${staged[@]}"; do
+  if is_partially_staged "$file"; then
+    partial+=("$file")
+  else
+    fully_staged+=("$file")
+  fi
+  modules+=("$(module_of "$file")")
+done
+mapfile -t modules < <(printf '%s\n' "${modules[@]}" | sort -u)
+
+projects=$(printf '%s,' "${modules[@]}")
+projects=${projects%,}
+
+echo "pre-commit: formatting staged Java sources in module(s): $projects"
+mvn -B -q -pl "$projects" -Drootlocation="$repo_root" \
+  formatter:format impsort:sort
+
+# Re-stage fully staged files so the formatting lands in this commit.
+if [[ ${#fully_staged[@]} -gt 0 ]]; then
+  git add -- "${fully_staged[@]}"
+fi
+
+# Warn about partially staged files: they were formatted on disk but not
+# re-staged, to avoid silently committing their unstaged hunks.
+if [[ ${#partial[@]} -gt 0 ]]; then
+  echo "pre-commit: WARNING - the following files have unstaged changes; they" >&2
+  echo "pre-commit: were formatted on disk but NOT re-staged. Review and add:" >&2
+  printf 'pre-commit:   %s\n' "${partial[@]}" >&2
+fi


### PR DESCRIPTION
## Summary

Closes #17. Adds a version-controlled git `pre-commit` hook that auto-formats staged Java files with the project's `formatter-maven-plugin` + `impsort-maven-plugin` configuration, so every commit already satisfies the CI `fastbuild` format gate. This removes the fix-push-recheck loop seen on PR #16.

## Changes

- **`src/build/hooks/pre-commit`** (new, executable) — collects staged Java files (`git diff --cached --diff-filter=ACM -- '*.java'`), scopes `mvn formatter:format impsort:sort` to the affected module(s) via `-pl`, passes `-Drootlocation` so `eclipse-codestyle.xml` resolves outside the reactor root, and re-stages fully-staged files. Partially-staged files are formatted on disk but **not** re-staged, to avoid silently committing unstaged hunks. No-op when no Java files are staged; warns but does not block if `mvn` is absent.
- **`pom.xml`** — new `install-git-hooks` profile wires `git-build-hook-maven-plugin:3.6.0` to install the hook into `.git/hooks/` on the `initialize` phase of any build (zero-touch for contributors). The profile is activated only when a `.git` directory exists, so it is a no-op for source-tarball builds and child modules.
- **`README.md`** — documents the hook, its self-install, the per-module formatting behavior, and `git commit --no-verify` to bypass.

## Verification

- `mvn -N initialize` installs the hook to `.git/hooks/pre-commit`, byte-identical to source
- Non-Java staged commit → no-op, exit 0
- Misformatted Java file → reformatted and re-staged
- Partially-staged file → formatted on disk, warned, not re-staged
- `shfmt -ln bash -i 2 -ci -s` and `shellcheck -P SCRIPTDIR -x` clean (matches the repo's CI shell-lint)
- `sortpom:verify` passes — `pom.xml` stays canonically sorted, so the `verifyformat` gate is unaffected

## Notes

`formatter-maven-plugin` operates per-module, not per-file, so the hook reformats all Java sources in the module(s) containing staged files. This is benign (formatting is idempotent) and documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)