### PR TITLE
Phase 2 / Slice 2: Polished refusal messages for foreign and corrupt markers

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -305,19 +305,19 @@ public class MiniAccumuloConfigImpl {
     String markerSchema = markerProps.getProperty("mac.marker.version");
     if (!MAC_MARKER_SCHEMA_VERSION.equals(markerSchema)) {
       throw new IllegalStateException(
-          "Refusing to resume: " + dirPath + " was initialized by a newer MAC " + "(marker version "
+          "Refusing to resume: " + dirPath + " was initialized by a newer MAC (marker version "
               + markerSchema + ", this binary expects " + MAC_MARKER_SCHEMA_VERSION
-              + "). Upgrade your MAC binary, or delete and " + "re-initialize.");
+              + "). Upgrade your MAC binary, or delete and re-initialize.");
     }
 
     String persistedVersion = markerProps.getProperty("accumulo.version");
     if (!Constants.VERSION.equals(persistedVersion)) {
-      throw new IllegalStateException(
-          "Refusing to resume: data dir " + dirPath + " was initialized with Accumulo "
-              + persistedVersion + ", current binary is " + Constants.VERSION + ".\n" + "\n"
-              + "This quickstart does not migrate data across versions. To proceed:\n"
-              + "  - Delete " + dirPath + " and run again to re-initialize with this binary, OR\n"
-              + "  - Re-install Accumulo " + persistedVersion + " to match the persisted data.");
+      throw new IllegalStateException("Refusing to resume: data dir " + dirPath
+          + " was initialized with Accumulo " + persistedVersion + ", current binary is "
+          + Constants.VERSION + ".\n\nThis quickstart does not migrate data across versions."
+          + " To proceed:\n  - Delete " + dirPath
+          + " and run again to re-initialize with this binary, OR\n  - Re-install Accumulo "
+          + persistedVersion + " to match the persisted data.");
     }
 
     File persistedSiteFile = new File(confDir, "accumulo.properties");

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -92,6 +92,13 @@ public class MiniAccumuloConfigImpl {
    */
   static final String MAC_MARKER_SCHEMA_VERSION = "1";
 
+  /**
+   * Marker fields that must be present (non-empty) for resume to proceed. See ADR-0007
+   * &sect;Decision-5.
+   */
+  static final String[] REQUIRED_MARKER_FIELDS =
+      {"mac.marker.version", "accumulo.version", "instance.name", "created.at"};
+
   private File dir = null;
   private String rootPassword = null;
   private Map<String,String> hadoopConfOverrides = new HashMap<>();
@@ -258,30 +265,59 @@ public class MiniAccumuloConfigImpl {
    * {@code conf/accumulo.properties}. The persisted values for {@code instance.volumes} and
    * {@code instance.secret} win over anything the caller set; other entries fill in unset keys but
    * defer to caller-supplied overrides. The instance name comes from the marker file.
+   *
+   * <p>
+   * The four refusal messages are contracted by ADR-0007 &sect;Decision-2 and &sect;Decision-6.
+   * Each failure mode produces its own distinct string; tests assert exact equality, so any edit
+   * here must be paired with the corresponding test update.
    */
   private void loadPersistedConfigForResume() {
     File marker = new File(dir, MAC_MARKER_FILENAME);
+    String dirPath = dir.getAbsolutePath();
+    String markerPath = marker.getAbsolutePath();
+
     if (!marker.exists()) {
-      throw new IllegalStateException("Refusing to resume: no MAC marker file at " + marker
-          + ". Data directory was not initialized by MiniAccumuloCluster.");
+      throw new IllegalStateException(
+          "Refusing to use " + dirPath + " as a data dir: not a MAC quickstart directory "
+              + "(missing mac-instance.properties marker). "
+              + "If you intend to start fresh here, delete " + dirPath + " and run again.");
     }
 
     Properties markerProps = new Properties();
     try (FileInputStream fis = new FileInputStream(marker)) {
       markerProps.load(fis);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Refusing to resume: failed to read MAC marker " + marker, e);
+    } catch (IOException | IllegalArgumentException e) {
+      // Properties.load() raises IllegalArgumentException on a malformed unicode escape sequence.
+      throw new IllegalStateException(
+          "Refusing to resume: " + markerPath
+              + " is corrupt or missing required fields. Delete the directory to re-initialize.",
+          e);
+    }
+
+    for (String field : REQUIRED_MARKER_FIELDS) {
+      String value = markerProps.getProperty(field);
+      if (value == null || value.isEmpty()) {
+        throw new IllegalStateException("Refusing to resume: " + markerPath
+            + " is corrupt or missing required fields. Delete the directory to re-initialize.");
+      }
+    }
+
+    String markerSchema = markerProps.getProperty("mac.marker.version");
+    if (!MAC_MARKER_SCHEMA_VERSION.equals(markerSchema)) {
+      throw new IllegalStateException(
+          "Refusing to resume: " + dirPath + " was initialized by a newer MAC " + "(marker version "
+              + markerSchema + ", this binary expects " + MAC_MARKER_SCHEMA_VERSION
+              + "). Upgrade your MAC binary, or delete and " + "re-initialize.");
     }
 
     String persistedVersion = markerProps.getProperty("accumulo.version");
-    if (persistedVersion == null) {
-      throw new IllegalStateException(
-          "Refusing to resume: marker " + marker + " is missing accumulo.version.");
-    }
     if (!Constants.VERSION.equals(persistedVersion)) {
       throw new IllegalStateException(
-          "Refusing to resume: data dir " + dir + " was initialized with Accumulo "
-              + persistedVersion + ", current binary is " + Constants.VERSION + ".");
+          "Refusing to resume: data dir " + dirPath + " was initialized with Accumulo "
+              + persistedVersion + ", current binary is " + Constants.VERSION + ".\n" + "\n"
+              + "This quickstart does not migrate data across versions. To proceed:\n"
+              + "  - Delete " + dirPath + " and run again to re-initialize with this binary, OR\n"
+              + "  - Re-install Accumulo " + persistedVersion + " to match the persisted data.");
     }
 
     File persistedSiteFile = new File(confDir, "accumulo.properties");

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -163,8 +163,80 @@ public class MiniAccumuloConfigImplTest {
 
     IllegalStateException ex = assertThrows(IllegalStateException.class,
         () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize());
-    assertTrue(ex.getMessage().contains("no MAC marker file"),
-        "message should explain missing marker, got: " + ex.getMessage());
+    String expected = "Refusing to use " + dir.getAbsolutePath()
+        + " as a data dir: not a MAC quickstart directory "
+        + "(missing mac-instance.properties marker). "
+        + "If you intend to start fresh here, delete " + dir.getAbsolutePath() + " and run again.";
+    assertEquals(expected, ex.getMessage());
+  }
+
+  @Test
+  public void resumeRefusesWhenMarkerCorruptIsUnparseable() throws IOException {
+    File dir = subDir("marker-unparseable");
+    // write a fresh marker so the dir starts as a valid MAC quickstart dir
+    new MiniAccumuloConfigImpl(dir, "password").initialize();
+    File marker = new File(dir, MiniAccumuloConfigImpl.MAC_MARKER_FILENAME);
+
+    // Overwrite with a malformed unicode escape so Properties.load throws
+    // IllegalArgumentException. The literal is split so the Java lexer does not try to interpret
+    // the source's backslash-u sequence as an actual unicode escape.
+    try (FileWriter fw = new FileWriter(marker, UTF_8)) {
+      fw.write("garbage=\\" + "uZZZZ\n");
+    }
+
+    IllegalStateException ex = assertThrows(IllegalStateException.class,
+        () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize());
+    String expected = "Refusing to resume: " + marker.getAbsolutePath()
+        + " is corrupt or missing required fields. Delete the directory to re-initialize.";
+    assertEquals(expected, ex.getMessage());
+  }
+
+  @Test
+  public void resumeRefusesWhenMarkerMissingRequiredField() throws IOException {
+    for (String required : MiniAccumuloConfigImpl.REQUIRED_MARKER_FIELDS) {
+      File dir = subDir("missing-" + required);
+      new MiniAccumuloConfigImpl(dir, "password").setInstanceName("req").initialize();
+      File marker = new File(dir, MiniAccumuloConfigImpl.MAC_MARKER_FILENAME);
+
+      Properties props = new Properties();
+      try (FileInputStream fis = new FileInputStream(marker)) {
+        props.load(fis);
+      }
+      props.remove(required);
+      try (FileWriter fw = new FileWriter(marker, UTF_8)) {
+        props.store(fw, "tampered: missing " + required);
+      }
+
+      IllegalStateException ex = assertThrows(IllegalStateException.class,
+          () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize(),
+          "expected refusal when " + required + " is absent");
+      String expected = "Refusing to resume: " + marker.getAbsolutePath()
+          + " is corrupt or missing required fields. Delete the directory to re-initialize.";
+      assertEquals(expected, ex.getMessage(), "wrong message for missing field " + required);
+    }
+  }
+
+  @Test
+  public void resumeRefusesOnNewerMarkerSchemaVersion() throws IOException {
+    File dir = subDir("schema-newer");
+    new MiniAccumuloConfigImpl(dir, "password").initialize();
+    File marker = new File(dir, MiniAccumuloConfigImpl.MAC_MARKER_FILENAME);
+
+    Properties props = new Properties();
+    try (FileInputStream fis = new FileInputStream(marker)) {
+      props.load(fis);
+    }
+    props.setProperty("mac.marker.version", "2");
+    try (FileWriter fw = new FileWriter(marker, UTF_8)) {
+      props.store(fw, "tampered: newer marker schema");
+    }
+
+    IllegalStateException ex = assertThrows(IllegalStateException.class,
+        () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize());
+    String expected = "Refusing to resume: " + dir.getAbsolutePath()
+        + " was initialized by a newer MAC " + "(marker version 2, this binary expects 1). "
+        + "Upgrade your MAC binary, or delete and re-initialize.";
+    assertEquals(expected, ex.getMessage());
   }
 
   @Test
@@ -187,10 +259,13 @@ public class MiniAccumuloConfigImplTest {
 
     IllegalStateException ex = assertThrows(IllegalStateException.class,
         () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize());
-    assertTrue(ex.getMessage().contains("9.99.99-FAKE"),
-        "message should mention the persisted version, got: " + ex.getMessage());
-    assertTrue(ex.getMessage().contains(Constants.VERSION),
-        "message should mention current binary version, got: " + ex.getMessage());
+    String expected = "Refusing to resume: data dir " + dir.getAbsolutePath()
+        + " was initialized with Accumulo 9.99.99-FAKE, current binary is " + Constants.VERSION
+        + ".\n" + "\n" + "This quickstart does not migrate data across versions. To proceed:\n"
+        + "  - Delete " + dir.getAbsolutePath()
+        + " and run again to re-initialize with this binary, OR\n"
+        + "  - Re-install Accumulo 9.99.99-FAKE to match the persisted data.";
+    assertEquals(expected, ex.getMessage());
   }
 
   @Test

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -178,10 +178,10 @@ public class MiniAccumuloConfigImplTest {
     File marker = new File(dir, MiniAccumuloConfigImpl.MAC_MARKER_FILENAME);
 
     // Overwrite with a malformed unicode escape so Properties.load throws
-    // IllegalArgumentException. The literal is split so the Java lexer does not try to interpret
-    // the source's backslash-u sequence as an actual unicode escape.
+    // IllegalArgumentException. The backslash is interpolated as a char literal so the Java lexer
+    // does not see an adjacent backslash-u in source (which would itself be parsed as an escape).
     try (FileWriter fw = new FileWriter(marker, UTF_8)) {
-      fw.write("garbage=\\" + "uZZZZ\n");
+      fw.write("garbage=" + '\\' + "uZZZZ\n");
     }
 
     IllegalStateException ex = assertThrows(IllegalStateException.class,
@@ -234,8 +234,9 @@ public class MiniAccumuloConfigImplTest {
     IllegalStateException ex = assertThrows(IllegalStateException.class,
         () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize());
     String expected = "Refusing to resume: " + dir.getAbsolutePath()
-        + " was initialized by a newer MAC " + "(marker version 2, this binary expects 1). "
-        + "Upgrade your MAC binary, or delete and re-initialize.";
+        + " was initialized by a newer MAC (marker version 2, this binary expects "
+        + MiniAccumuloConfigImpl.MAC_MARKER_SCHEMA_VERSION
+        + "). Upgrade your MAC binary, or delete and re-initialize.";
     assertEquals(expected, ex.getMessage());
   }
 
@@ -261,10 +262,10 @@ public class MiniAccumuloConfigImplTest {
         () -> new MiniAccumuloConfigImpl(dir, "password").resume().initialize());
     String expected = "Refusing to resume: data dir " + dir.getAbsolutePath()
         + " was initialized with Accumulo 9.99.99-FAKE, current binary is " + Constants.VERSION
-        + ".\n" + "\n" + "This quickstart does not migrate data across versions. To proceed:\n"
-        + "  - Delete " + dir.getAbsolutePath()
-        + " and run again to re-initialize with this binary, OR\n"
-        + "  - Re-install Accumulo 9.99.99-FAKE to match the persisted data.";
+        + ".\n\nThis quickstart does not migrate data across versions. To proceed:\n  - Delete "
+        + dir.getAbsolutePath()
+        + " and run again to re-initialize with this binary, OR\n  - Re-install Accumulo"
+        + " 9.99.99-FAKE to match the persisted data.";
     assertEquals(expected, ex.getMessage());
   }
 


### PR DESCRIPTION
## Summary

Implements the four distinct refusal messages contracted by [ADR-0007 §Decision-2 and §Decision-6](docs/adr/0007-mac-resume-mode-for-data-dir-persistence.md) on the `MiniAccumuloConfigImpl.initialize()` resume path. Each failure mode now produces its own specific string instead of the basic strings from Slice 1; unit tests assert exact equality so any future drift fails fast.

### The four refusal cases

`loadPersistedConfigForResume()` validates in this order:

1. **Marker absent** — `Refusing to use <path> as a data dir: not a MAC quickstart directory (missing mac-instance.properties marker). If you intend to start fresh here, delete <path> and run again.`
2. **Marker unparseable OR missing any required field** — `Refusing to resume: <path>/mac-instance.properties is corrupt or missing required fields. Delete the directory to re-initialize.`  `IllegalArgumentException` from `Properties.load` on a malformed unicode escape is caught alongside `IOException` so both reach the same message.
3. **`mac.marker.version` != `1`** — `Refusing to resume: <path> was initialized by a newer MAC (marker version <N>, this binary expects 1). Upgrade your MAC binary, or delete and re-initialize.`
4. **`accumulo.version` mismatch** — the full ADR §Decision-6 message including the path, both versions, and the two-bullet remediation block.

Required marker fields are pulled from a new `REQUIRED_MARKER_FIELDS` constant: `mac.marker.version`, `accumulo.version`, `instance.name`, `created.at`.

### Tests

- `resumeRefusesWhenMarkerAbsent` and `resumeRefusesOnVersionMismatch` now assert exact strings (previously `contains` checks).
- Three new tests cover the corrupt-marker (malformed unicode escape), missing-required-field (looped across all four fields), and newer-marker-schema cases.

No escape-hatch flag is added (per ADR §Decision-6).

Closes #34.

## Test plan

- [x] `mvn test -pl minicluster -am -Dtest=MiniAccumuloConfigImplTest` — 13 tests, all green
- [x] `mvn validate -DverifyFormat -pl minicluster -am` — formatter:validate passes
- [x] `mvn process-test-resources -DverifyFormat -DskipTests -pl minicluster -am` — impsort:check passes
- [x] No non-ASCII characters in changed files (the CI ASCII gate that bit Slice 1 stays green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)