### PR TITLE
Phase 2 / Slice 3: Root-password mismatch refusal on resume

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -349,6 +349,27 @@ public class MiniAccumuloConfigImpl {
     if (persistedInstanceName != null && !persistedInstanceName.isEmpty()) {
       instanceName = persistedInstanceName;
     }
+
+    File persistedClientFile = new File(confDir, "accumulo-client.properties");
+    if (!persistedClientFile.exists()) {
+      throw new IllegalStateException(
+          "Refusing to resume: persisted accumulo-client.properties is missing: "
+              + persistedClientFile);
+    }
+    Properties persistedClientProps = new Properties();
+    try (FileInputStream fis = new FileInputStream(persistedClientFile)) {
+      persistedClientProps.load(fis);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Refusing to resume: failed to read " + persistedClientFile,
+          e);
+    }
+    String persistedRootPassword =
+        persistedClientProps.getProperty(ClientProperty.AUTH_TOKEN.getKey());
+    if (!Objects.equals(rootPassword, persistedRootPassword)) {
+      throw new IllegalStateException("Refusing to resume: data dir " + dirPath
+          + " was initialized with a different root password."
+          + " Pass the original password or delete " + dirPath + " to re-initialize.");
+    }
   }
 
   /**

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterResumeTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterResumeTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.miniclusterImpl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -123,5 +124,23 @@ public class MiniAccumuloClusterResumeTest extends WithTestNames {
     IllegalStateException ex = assertThrows(IllegalStateException.class,
         () -> new MiniAccumuloConfigImpl(dir, PASSWORD).resume().initialize());
     assertTrue(ex.getMessage().contains("9.99.99-FAKE"));
+  }
+
+  @Test
+  @Timeout(120)
+  public void resumeRefusesAfterRootPasswordMismatch() throws Exception {
+    File dir = freshTestDir();
+
+    MiniAccumuloClusterImpl fresh =
+        new MiniAccumuloClusterImpl(new MiniAccumuloConfigImpl(dir, PASSWORD));
+    fresh.start();
+    fresh.stop();
+
+    IllegalStateException ex = assertThrows(IllegalStateException.class,
+        () -> new MiniAccumuloConfigImpl(dir, "differentPw").resume().initialize());
+    String expected = "Refusing to resume: data dir " + dir.getAbsolutePath()
+        + " was initialized with a different root password."
+        + " Pass the original password or delete " + dir.getAbsolutePath() + " to re-initialize.";
+    assertEquals(expected, ex.getMessage());
   }
 }

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.minicluster.ServerType;
@@ -286,6 +287,7 @@ public class MiniAccumuloConfigImplTest {
     try (FileWriter fw = new FileWriter(new File(confDir, "accumulo.properties"), UTF_8)) {
       persisted.store(fw, null);
     }
+    writePersistedClientProps(confDir, "password");
 
     // resume: empty-dir guard must NOT fire, locked fields come from persisted, user's
     // attempted override of INSTANCE_SECRET is ignored.
@@ -297,6 +299,64 @@ public class MiniAccumuloConfigImplTest {
     assertEquals("persistedSecret", resumed.getSiteConfig().get(Property.INSTANCE_SECRET.getKey()),
         "locked instance.secret must come from persisted accumulo.properties");
     assertEquals("locked", resumed.getInstanceName(), "instance name should come from marker");
+  }
+
+  @Test
+  public void resumeProceedsWhenRootPasswordMatches() throws IOException {
+    File dir = subDir("rootpw-match");
+    new MiniAccumuloConfigImpl(dir, "originalPw").setInstanceName("rootpw").initialize();
+    File confDir = new File(dir, "conf");
+    writePersistedAccumuloProps(confDir, dir);
+    writePersistedClientProps(confDir, "originalPw");
+
+    MiniAccumuloConfigImpl resumed =
+        new MiniAccumuloConfigImpl(dir, "originalPw").resume().initialize();
+    assertTrue(resumed.isResumeMode());
+    assertEquals("originalPw", resumed.getRootPassword(),
+        "user-supplied root password should be preserved when it matches the persisted value");
+  }
+
+  @Test
+  public void resumeRefusesOnRootPasswordMismatch() throws IOException {
+    File dir = subDir("rootpw-mismatch");
+    new MiniAccumuloConfigImpl(dir, "originalPw").setInstanceName("rootpw").initialize();
+    File confDir = new File(dir, "conf");
+    writePersistedAccumuloProps(confDir, dir);
+    writePersistedClientProps(confDir, "originalPw");
+
+    IllegalStateException ex = assertThrows(IllegalStateException.class,
+        () -> new MiniAccumuloConfigImpl(dir, "wrongPw").resume().initialize());
+    String expected = "Refusing to resume: data dir " + dir.getAbsolutePath()
+        + " was initialized with a different root password."
+        + " Pass the original password or delete " + dir.getAbsolutePath() + " to re-initialize.";
+    assertEquals(expected, ex.getMessage());
+
+    // The persisted password must never be silently substituted for the user's mismatched value:
+    // the throw above is the only acceptable outcome.
+  }
+
+  private static void writePersistedAccumuloProps(File confDir, File dir) throws IOException {
+    assertTrue(confDir.mkdirs() || confDir.isDirectory());
+    Properties persisted = new Properties();
+    persisted.setProperty(Property.INSTANCE_VOLUMES.getKey(),
+        "file://" + new File(dir, "accumulo").getAbsolutePath());
+    persisted.setProperty(Property.INSTANCE_SECRET.getKey(), "persistedSecret");
+    persisted.setProperty(Property.INSTANCE_ZK_HOST.getKey(), "127.0.0.1:12345");
+    try (FileWriter fw = new FileWriter(new File(confDir, "accumulo.properties"), UTF_8)) {
+      persisted.store(fw, null);
+    }
+  }
+
+  private static void writePersistedClientProps(File confDir, String rootPassword)
+      throws IOException {
+    assertTrue(confDir.mkdirs() || confDir.isDirectory());
+    Properties persisted = new Properties();
+    persisted.setProperty(ClientProperty.AUTH_TYPE.getKey(), "password");
+    persisted.setProperty(ClientProperty.AUTH_PRINCIPAL.getKey(), "root");
+    persisted.setProperty(ClientProperty.AUTH_TOKEN.getKey(), rootPassword);
+    try (FileWriter fw = new FileWriter(new File(confDir, "accumulo-client.properties"), UTF_8)) {
+      persisted.store(fw, null);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

Implements the root-credential half of [ADR-0007 §Decision-4](https://github.com/zachradtka/newccumulo/blob/main/docs/adr/0007-mac-resume-mode-for-data-dir-persistence.md). On resume, the user's currently-configured root password must match the `auth.token` persisted in the data dir's `conf/accumulo-client.properties`. Mismatch refuses with the issue-contracted error message naming the data-dir path; match proceeds normally. The persisted password is never silently substituted for the user's mismatched value. No bypass flag is added.

- **Production** ([MiniAccumuloConfigImpl.java](https://github.com/zachradtka/newccumulo/blob/phase-2-slice-3-root-password-refusal/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java)): new block at the end of `loadPersistedConfigForResume()` reads the persisted client.properties, pulls `auth.token`, and compares against `this.rootPassword` via `Objects.equals`. Missing client.properties throws (parallels the existing accumulo.properties handling). Mismatch throws `IllegalStateException` with the contracted message, with `dirPath` substituted twice.
- **Unit tests** ([MiniAccumuloConfigImplTest.java](https://github.com/zachradtka/newccumulo/blob/phase-2-slice-3-root-password-refusal/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java)): `resumeProceedsWhenRootPasswordMatches` (match path preserves user-supplied password) and `resumeRefusesOnRootPasswordMismatch` (asserts exact error string). The pre-existing `resumeSkipsEmptyDirGuardAndLoadsLockedFields` test now also writes a matching client.properties so it still passes with the new check in place.
- **Integration test** ([MiniAccumuloClusterResumeTest.java](https://github.com/zachradtka/newccumulo/blob/phase-2-slice-3-root-password-refusal/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterResumeTest.java)): `resumeRefusesAfterRootPasswordMismatch` spawns a fresh MAC under `PASSWORD`, stops it, then attempts resume with a different password and asserts the exact refusal string. Parallels the existing tampered-marker integration test.

Closes #35.

## Test plan
- [x] `mvn -pl minicluster -am test -Dtest=MiniAccumuloConfigImplTest` — 15/15 pass
- [x] `mvn -pl minicluster -am test -Dtest=MiniAccumuloClusterResumeTest` — 3/3 pass (~32s)
- [x] `mvn clean package -DskipTests -DverifyFormat` — fastbuild gate clean
- [x] `src/build/ci/find-unapproved-chars.sh` — 0 unapproved chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)