### PR TITLE
Phase 2 / Slice 4: Quickstart CLI persistence via --data-dir (#36)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -215,7 +215,7 @@ All flags are passed to `accumulo quickstart` (native) or appended to the
 | `--compactors <n>` | `1` | Number of compactors (must be ≥ 1). Accepted and validated; compactor JVMs are not started in this release. |
 | `--heap-mb <n>` | `256` | Per-service JVM heap size, in megabytes. |
 | `--root-password <pw>` | `secret` | Root user password. Overrides `ACCUMULO_ROOT_PASSWORD`. |
-| `--data-dir <path>` | — | **Not yet supported.** Persistent data directory — a Phase 2 feature. Passing it fails fast with a clear error. See [Persistence](#persistence). |
+| `--data-dir <path>` | — | Persistent data directory. With the flag, the cluster stores state at the path and a later run against the same path resumes from it. Without the flag, an ephemeral temp dir is used and deleted on shutdown. See [Persistence](#persistence). |
 
 `--port-base` and the per-service port flags (`--zk-port`, `--manager-port`,
 `--tserver-port`, `--monitor-port`) cannot be combined; supplying both forms is
@@ -231,23 +231,34 @@ an error.
 
 ## Persistence
 
-**Phase 1 (this release) is ephemeral.** Every quickstart run — native or
-Docker — stores its data in a fresh temporary directory that is deleted when
-the cluster stops. The ready banner tags the data dir line `(ephemeral)` to
-make this explicit. Nothing survives a restart.
+By default the quickstart is ephemeral: each run stores its data in a fresh
+temporary directory that is deleted when the cluster stops. The ready banner
+tags the data dir line `(ephemeral)` so the disposition is unambiguous.
 
-Persistent storage via a `--data-dir` flag is a **Phase 2** feature and is not
-available yet. If you pass `--data-dir`, the quickstart fails fast rather than
-misleading you:
+Pass `--data-dir <path>` to make the run persistent. The first run initializes
+the supplied path; subsequent runs against the same path resume from it,
+preserving tables, data, and configured users. The `(ephemeral)` tag is dropped
+from the banner.
 
 ```
-Persistence via --data-dir is not yet supported in this release. See zachradtka/newccumulo#8 for status.
+accumulo quickstart --data-dir /var/lib/accumulo
 ```
 
-The Docker image already reserves a `/data` volume for this future support, but
-in this release that volume is unused and the data directory remains the
-container's ephemeral temp space. Track progress in
-[issue #8](https://github.com/zachradtka/newccumulo/issues/8).
+Restrictions on resume (see
+[ADR-0007](adr/0007-mac-resume-mode-for-data-dir-persistence.md) for the full
+rationale):
+
+- The Accumulo binary that resumes must be the exact same version that
+  initialized the directory; mixing versions is refused with a clear message.
+- A directory that was not initialized by this quickstart (no
+  `mac-instance.properties` marker at its root) is refused rather than reused.
+- The root password must match the one the directory was initialized with;
+  mismatched passwords are refused at startup. Override with `--root-password`
+  or `ACCUMULO_ROOT_PASSWORD` to supply the original password.
+- Refusal is recoverable: delete the data dir and re-run to start fresh.
+
+The Docker image reserves a `/data` volume which is the natural target for
+`--data-dir /data` when running against a host-mounted volume.
 
 ## Security caveat
 
@@ -277,9 +288,21 @@ one of the default ports. Free it, or shift the quickstart's ports with
 `--port-base 21810` to move all four at once, or with the individual
 `--zk-port` / `--manager-port` / `--tserver-port` / `--monitor-port` flags.
 
-**`Persistence via --data-dir is not yet supported ...`**
-You passed `--data-dir`. It is a Phase 2 feature; remove the flag. See
-[Persistence](#persistence).
+**`Refusing to use ... as a data dir: not a MAC quickstart directory (missing mac-instance.properties marker)`**
+You pointed `--data-dir` at a non-empty directory that this quickstart did not
+initialize. Either choose an empty (or nonexistent) path, or delete the
+existing contents and run again to start fresh.
+
+**`Refusing to resume: data dir ... was initialized with Accumulo X, current binary is Y.`**
+The binary you are running does not match the one that initialized the data
+directory. Either re-install the original version to match the persisted data,
+or delete the data dir and re-initialize with the current binary. The
+quickstart does not migrate data across versions.
+
+**`Refusing to resume: data dir ... was initialized with a different root password.`**
+The supplied `--root-password` (or `ACCUMULO_ROOT_PASSWORD`) does not match the
+password that initialized the data dir. Supply the original password, or
+delete the data dir to re-initialize.
 
 **`Quickstart failed to become ready`**
 The cluster did not accept connections within the readiness timeout (60s).

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/Quickstart.java
@@ -106,9 +106,36 @@ public class Quickstart {
       System.exit(1);
     }
 
-    Path dataDir = Files.createTempDirectory("accumulo-quickstart-");
+    QuickstartConfig.DataDirPlan plan = config.resolveDataDirPlan();
+    Path dataDir;
+    if (plan.ephemeral()) {
+      dataDir = Files.createTempDirectory("accumulo-quickstart-");
+    } else {
+      dataDir = plan.path().toPath();
+      // The plan dispatches FRESH_AT_PATH for "nonexistent or empty". MAC will materialize its
+      // own subdirs (conf, accumulo, zookeeper, logs) but expects the data-dir root to exist for
+      // marker writing. mkdirs is a no-op if the dir is already there.
+      if (!plan.resumeMode() && !dataDir.toFile().exists()) {
+        Files.createDirectories(dataDir);
+      }
+    }
+
     MiniAccumuloConfig macConfig = config.toMiniAccumuloConfig(dataDir.toFile());
-    MiniAccumuloCluster cluster = new MiniAccumuloCluster(macConfig);
+    if (plan.resumeMode()) {
+      macConfig.getImpl().resume();
+    }
+    MiniAccumuloCluster cluster;
+    try {
+      cluster = new MiniAccumuloCluster(macConfig);
+    } catch (RuntimeException ex) {
+      // MAC raises IllegalStateException / IllegalArgumentException from initialize() for resume
+      // refusals (foreign dir, corrupt marker, version mismatch, password mismatch) and the
+      // "not a directory" guard. Slices 2 and 3 contracted the exact wording; surface MAC's
+      // message verbatim to stderr rather than wrapping it.
+      System.err.println(ex.getMessage());
+      System.exit(1);
+      return;
+    }
 
     // MAC's embedded ZK hardcodes clientPortAddress=127.0.0.1 in the generated zoo.cfg, which is
     // independent of Accumulo's rpc.bind.addr - the Property only controls Accumulo's own services
@@ -121,8 +148,9 @@ public class Quickstart {
       overrideZooKeeperClientPortAddress(macConfig, config.bindAddress());
     }
 
-    Runtime.getRuntime()
-        .addShutdownHook(new Thread(() -> shutdown(dataDir), "quickstart-shutdown"));
+    boolean deleteOnShutdown = plan.ephemeral();
+    Runtime.getRuntime().addShutdownHook(
+        new Thread(() -> shutdown(dataDir, deleteOnShutdown), "quickstart-shutdown"));
 
     cluster.start();
 
@@ -172,7 +200,7 @@ public class Quickstart {
     String banner =
         QuickstartBanner.format(new QuickstartBanner.BannerInputs(cluster.getInstanceName(),
             "http://" + monitorHost + ":" + config.monitorPort(), zooKeepers, config.rootPassword(),
-            dataDir.toAbsolutePath().toString(), true, config.shouldWarnInsecure()));
+            dataDir.toAbsolutePath().toString(), plan.ephemeral(), config.shouldWarnInsecure()));
     System.out.print(banner);
     System.out.flush();
 
@@ -241,15 +269,21 @@ public class Quickstart {
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
-      justification = "dataDir is a JVM-created temp directory, not a user-supplied path; "
+      justification = "dataDir is a JVM-created temp directory in the ephemeral case, or a "
+          + "user-supplied --data-dir path which is only deleted when the cluster owns it; "
           + "quickstart is a user-facing local CLI")
-  private static void shutdown(Path dataDir) {
+  private static void shutdown(Path dataDir, boolean deleteDataDir) {
     // Walk our own child processes (MAC spawns one JVM per service via ProcessBuilder, so they're
     // direct children of this JVM) and SIGKILL anything still alive. In the Ctrl-C case the
     // SIGINT already propagated to them through the foreground process group and they're dying or
     // dead - destroyForcibly is a no-op on a dead process. In the kill -TERM case (signal only to
     // the parent), this is what actually stops them. Either way, no ZK round-trip required.
     killChildJvms();
+    if (!deleteDataDir) {
+      // --data-dir was supplied; the user owns the directory and expects to resume from it on
+      // the next run. Removing it would defeat the entire point of the flag.
+      return;
+    }
     try {
       FileUtils.deleteDirectory(new File(dataDir.toString()));
     } catch (IOException e) {

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -30,6 +30,8 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Immutable value object holding the user-facing configuration for {@link Quickstart}. Translates
  * to a fully-realized {@link MiniAccumuloConfig} via {@link #toMiniAccumuloConfig(File)}.
@@ -313,6 +315,9 @@ public final class QuickstartConfig {
    * &rarr; {@link Disposition#RESUME_AT_PATH}. The Quickstart layer never validates the marker
    * itself; that is MAC's job, and any refusal message from MAC propagates unchanged.
    */
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
+      justification = "--data-dir is a user-supplied path by design; this is a user-facing local "
+          + "CLI and the very purpose of the flag is to operate on the path the user passed")
   public DataDirPlan resolveDataDirPlan() {
     if (dataDir == null) {
       return new DataDirPlan(Disposition.EPHEMERAL_TEMP, null);

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/QuickstartConfig.java
@@ -89,19 +89,29 @@ public final class QuickstartConfig {
   private final Duration readinessTimeout;
   private final String bindAddress;
   private final String advertiseAddress;
+  private final String dataDir;
 
   public QuickstartConfig(String instanceName, String rootPassword, int zooKeeperPort,
       int monitorPort, int managerPort, int tabletServerPort, int numTabletServers,
       int numScanServers, int numCompactors, int heapMb, Duration readinessTimeout) {
     this(instanceName, rootPassword, zooKeeperPort, monitorPort, managerPort, tabletServerPort,
         numTabletServers, numScanServers, numCompactors, heapMb, readinessTimeout,
-        DEFAULT_BIND_ADDRESS, DEFAULT_ADVERTISE_ADDRESS);
+        DEFAULT_BIND_ADDRESS, DEFAULT_ADVERTISE_ADDRESS, null);
   }
 
   public QuickstartConfig(String instanceName, String rootPassword, int zooKeeperPort,
       int monitorPort, int managerPort, int tabletServerPort, int numTabletServers,
       int numScanServers, int numCompactors, int heapMb, Duration readinessTimeout,
       String bindAddress, String advertiseAddress) {
+    this(instanceName, rootPassword, zooKeeperPort, monitorPort, managerPort, tabletServerPort,
+        numTabletServers, numScanServers, numCompactors, heapMb, readinessTimeout, bindAddress,
+        advertiseAddress, null);
+  }
+
+  public QuickstartConfig(String instanceName, String rootPassword, int zooKeeperPort,
+      int monitorPort, int managerPort, int tabletServerPort, int numTabletServers,
+      int numScanServers, int numCompactors, int heapMb, Duration readinessTimeout,
+      String bindAddress, String advertiseAddress, String dataDir) {
     Objects.requireNonNull(instanceName, "instanceName");
     Objects.requireNonNull(rootPassword, "rootPassword");
     Objects.requireNonNull(readinessTimeout, "readinessTimeout");
@@ -146,6 +156,7 @@ public final class QuickstartConfig {
     this.readinessTimeout = readinessTimeout;
     this.bindAddress = bindAddress;
     this.advertiseAddress = advertiseAddress;
+    this.dataDir = dataDir;
   }
 
   private static void requireValidPort(int port, String name) {
@@ -223,6 +234,102 @@ public final class QuickstartConfig {
    */
   public String advertiseAddress() {
     return advertiseAddress;
+  }
+
+  /**
+   * @return the user-supplied {@code --data-dir} path verbatim, or {@code null} if the flag was not
+   *         passed. Callers should normally consult {@link #resolveDataDirPlan()} to decide
+   *         lifecycle mode rather than inspecting this raw value themselves.
+   */
+  public String dataDir() {
+    return dataDir;
+  }
+
+  /**
+   * Quickstart-layer plan for what MAC should do with the {@code --data-dir} flag. This is the
+   * decision tree from ADR-0007 &sect;Decision-2 (Quickstart, not MAC, owns the runtime choice of
+   * when to call {@code .resume()}). Each {@link Disposition} maps one row of that table.
+   */
+  public enum Disposition {
+    /** No {@code --data-dir} supplied; caller mints and owns an ephemeral temp dir. Fresh mode. */
+    EPHEMERAL_TEMP,
+    /**
+     * {@code --data-dir} supplied and the path is empty or does not exist. MAC initializes fresh
+     * into the path; the caller is responsible for any required {@code mkdir -p}.
+     */
+    FRESH_AT_PATH,
+    /**
+     * {@code --data-dir} supplied and the path is a non-empty directory (or a regular file). MAC
+     * resumes against the path; refusals from marker validation propagate from MAC to stderr.
+     */
+    RESUME_AT_PATH
+  }
+
+  /**
+   * Immutable result of {@link #resolveDataDirPlan()}. The path is {@code null} only for
+   * {@link Disposition#EPHEMERAL_TEMP} (the caller has not minted a temp dir yet); it is the
+   * absolute form of the user-supplied path for the other two dispositions.
+   */
+  public static final class DataDirPlan {
+
+    private final Disposition disposition;
+    private final File path;
+
+    DataDirPlan(Disposition disposition, File path) {
+      this.disposition = Objects.requireNonNull(disposition, "disposition");
+      this.path = path;
+    }
+
+    public Disposition disposition() {
+      return disposition;
+    }
+
+    /**
+     * @return the resolved (absolute) path the caller should hand to MAC, or {@code null} for
+     *         {@link Disposition#EPHEMERAL_TEMP} where the caller mints its own temp dir.
+     */
+    public File path() {
+      return path;
+    }
+
+    /** @return true when the data dir is an ephemeral temp dir that should be deleted on stop. */
+    public boolean ephemeral() {
+      return disposition == Disposition.EPHEMERAL_TEMP;
+    }
+
+    /** @return true when MAC should be configured with {@code resume()} before start. */
+    public boolean resumeMode() {
+      return disposition == Disposition.RESUME_AT_PATH;
+    }
+  }
+
+  /**
+   * Resolve the {@link DataDirPlan} for this configuration by inspecting the current filesystem
+   * state of {@link #dataDir()}.
+   *
+   * <p>
+   * Decision tree (ADR-0007 &sect;Decision-2): no flag &rarr; {@link Disposition#EPHEMERAL_TEMP};
+   * flag supplied + nonexistent or empty path &rarr; {@link Disposition#FRESH_AT_PATH}; otherwise
+   * &rarr; {@link Disposition#RESUME_AT_PATH}. The Quickstart layer never validates the marker
+   * itself; that is MAC's job, and any refusal message from MAC propagates unchanged.
+   */
+  public DataDirPlan resolveDataDirPlan() {
+    if (dataDir == null) {
+      return new DataDirPlan(Disposition.EPHEMERAL_TEMP, null);
+    }
+    File dir = new File(dataDir).getAbsoluteFile();
+    if (!dir.exists()) {
+      return new DataDirPlan(Disposition.FRESH_AT_PATH, dir);
+    }
+    if (dir.isDirectory()) {
+      String[] children = dir.list();
+      if (children == null || children.length == 0) {
+        return new DataDirPlan(Disposition.FRESH_AT_PATH, dir);
+      }
+    }
+    // Either a non-empty directory or a regular file at this path. Hand it to MAC in resume mode;
+    // MAC's marker check (or its "directory, not file" guard) will produce the specific refusal.
+    return new DataDirPlan(Disposition.RESUME_AT_PATH, dir);
   }
 
   /**
@@ -351,8 +458,9 @@ public final class QuickstartConfig {
     String rootPassword;
 
     @Parameter(names = "--data-dir",
-        description = "Persistent data directory. Phase 2 feature - not yet supported in this "
-            + "release; see zachradtka/newccumulo#8.")
+        description = "Persistent data directory. If supplied, the cluster persists its state at "
+            + "this path and a subsequent run against the same path resumes from it. If omitted, "
+            + "an ephemeral temp dir is used and deleted on shutdown.")
     String dataDir;
   }
 
@@ -436,14 +544,6 @@ public final class QuickstartConfig {
       return ParseResult.helpRequested(formatUsage(jc));
     }
 
-    // --data-dir is reserved for Phase 2 persistence (zachradtka/newccumulo#8). Phase 1 always
-    // runs against an ephemeral temp directory the JVM removes on shutdown, so reject the flag
-    // outright rather than accepting it and silently discarding the user's data on the next run.
-    if (parsed.dataDir != null) {
-      return ParseResult.error("Persistence via --data-dir is not yet supported in this release. "
-          + "See zachradtka/newccumulo#8 for status.");
-    }
-
     boolean anyPerServicePort = parsed.zkPort != null || parsed.monitorPort != null
         || parsed.tserverPort != null || parsed.managerPort != null;
     if (parsed.portBase != null && anyPerServicePort) {
@@ -485,7 +585,7 @@ public final class QuickstartConfig {
     try {
       return ParseResult.success(new QuickstartConfig(DEFAULT_INSTANCE_NAME, rootPassword, zkPort,
           monitorPort, managerPort, tserverPort, numTservers, numScanServers, numCompactors, heapMb,
-          DEFAULT_READINESS_TIMEOUT, bindAddress, advertiseAddress));
+          DEFAULT_READINESS_TIMEOUT, bindAddress, advertiseAddress, parsed.dataDir));
     } catch (IllegalArgumentException ex) {
       return ParseResult.error(ex.getMessage());
     }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartConfigTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
@@ -442,17 +443,19 @@ public class QuickstartConfigTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Slice 6: --data-dir is a Phase 2 feature and must error with a clear message
+  // Phase 2 / Slice 4: --data-dir parsing and decision tree (ADR-0007 Decision-2)
   // ---------------------------------------------------------------------------
 
   @Test
-  public void parseDataDirYieldsClearNotSupportedError() {
-    ParseResult r = parseRaw(Collections.emptyMap(), "--data-dir", "/var/lib/accumulo");
-    assertEquals(ParseResult.Kind.ERROR, r.kind());
-    assertTrue(r.message().contains("--data-dir is not yet supported"),
-        () -> "error should explain --data-dir is unsupported; got: " + r.message());
-    assertTrue(r.message().contains("zachradtka/newccumulo#8"),
-        () -> "error should point at the Phase 2 tracking issue; got: " + r.message());
+  public void parseDataDirIsAcceptedAndExposedOnConfig() {
+    QuickstartConfig c = parseOk("--data-dir", "/var/lib/accumulo");
+    assertEquals("/var/lib/accumulo", c.dataDir());
+  }
+
+  @Test
+  public void parseNoDataDirLeavesItNull() {
+    QuickstartConfig c = parseOk();
+    assertEquals(null, c.dataDir());
   }
 
   @Test
@@ -460,15 +463,9 @@ public class QuickstartConfigTest {
     ParseResult r = parseRaw(Collections.emptyMap(), "--help");
     assertEquals(ParseResult.Kind.HELP, r.kind());
     assertTrue(r.message().contains("--data-dir"),
-        () -> "help should list --data-dir so users discover its Phase 2 status; got:\n"
-            + r.message());
-  }
-
-  @Test
-  public void parseHelpWinsOverDataDir() {
-    ParseResult r = parseRaw(Collections.emptyMap(), "--data-dir", "/tmp/x", "--help");
-    assertEquals(ParseResult.Kind.HELP, r.kind(),
-        () -> "--help must short-circuit before the --data-dir rejection; got " + r.kind());
+        () -> "help should list --data-dir; got:\n" + r.message());
+    assertTrue(!r.message().contains("not yet supported"),
+        () -> "help must not claim --data-dir is unsupported anymore; got:\n" + r.message());
   }
 
   @Test
@@ -482,5 +479,106 @@ public class QuickstartConfigTest {
     assertEquals(2181, cfg.getZooKeeperPort());
     assertTrue(!cfg.getDir().exists() || cfg.getDir().list().length == 0,
         "translate must produce an empty/nonexistent dir MAC will accept");
+  }
+
+  @Test
+  public void resolveDataDirPlanWithNoFlagYieldsEphemeral() {
+    QuickstartConfig c = parseOk();
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.EPHEMERAL_TEMP, plan.disposition());
+    assertTrue(plan.ephemeral(), "no --data-dir must be ephemeral");
+    assertTrue(!plan.resumeMode(), "no --data-dir must not request resume");
+    assertEquals(null, plan.path(),
+        "ephemeral plan must not carry a path; caller mints the temp dir");
+  }
+
+  @Test
+  public void resolveDataDirPlanWithNonexistentPathIsFresh() {
+    File dir = tmp.resolve("does-not-exist-yet").toFile();
+    assertTrue(!dir.exists(), "test precondition: directory must not exist");
+    QuickstartConfig c = parseOk("--data-dir", dir.getAbsolutePath());
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.FRESH_AT_PATH, plan.disposition());
+    assertTrue(!plan.ephemeral(), "supplied --data-dir must not be ephemeral");
+    assertTrue(!plan.resumeMode(), "nonexistent path must dispatch fresh, not resume");
+    assertEquals(dir.getAbsoluteFile(), plan.path());
+  }
+
+  @Test
+  public void resolveDataDirPlanWithEmptyDirIsFresh() throws IOException {
+    File dir = tmp.resolve("empty").toFile();
+    assertTrue(dir.mkdirs(), "test precondition: created empty dir");
+    QuickstartConfig c = parseOk("--data-dir", dir.getAbsolutePath());
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.FRESH_AT_PATH, plan.disposition());
+    assertTrue(!plan.resumeMode());
+    assertEquals(dir.getAbsoluteFile(), plan.path());
+  }
+
+  @Test
+  public void resolveDataDirPlanWithPopulatedDirRequestsResume() throws IOException {
+    File dir = tmp.resolve("populated").toFile();
+    assertTrue(dir.mkdirs());
+    assertTrue(new File(dir, "some-leftover").createNewFile(),
+        "test precondition: dropped a file so the dir is non-empty");
+    QuickstartConfig c = parseOk("--data-dir", dir.getAbsolutePath());
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.RESUME_AT_PATH, plan.disposition());
+    assertTrue(plan.resumeMode(), "non-empty dir must request resume; MAC then validates marker");
+    assertTrue(!plan.ephemeral());
+    assertEquals(dir.getAbsoluteFile(), plan.path());
+  }
+
+  @Test
+  public void resolveDataDirPlanWithDirContainingMarkerRequestsResume() throws IOException {
+    File dir = tmp.resolve("with-marker").toFile();
+    assertTrue(dir.mkdirs());
+    assertTrue(new File(dir, "mac-instance.properties").createNewFile());
+    QuickstartConfig c = parseOk("--data-dir", dir.getAbsolutePath());
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.RESUME_AT_PATH, plan.disposition());
+    assertTrue(plan.resumeMode());
+  }
+
+  @Test
+  public void resolveDataDirPlanRoutesRegularFileThroughResume() throws IOException {
+    // A regular file at --data-dir is not a directory at all. Either disposition lets MAC's
+    // "must pass in directory" guard produce the actual error; the plan picks resume because
+    // the path is non-empty (it exists and is not an empty directory).
+    File file = tmp.resolve("not-a-dir.txt").toFile();
+    assertTrue(file.createNewFile());
+    QuickstartConfig c = parseOk("--data-dir", file.getAbsolutePath());
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.RESUME_AT_PATH, plan.disposition());
+  }
+
+  @Test
+  public void resolveDataDirPlanReturnsAbsolutePath() throws IOException {
+    File dir = tmp.resolve("relativeish").toFile();
+    assertTrue(dir.mkdirs());
+    // Construct a QuickstartConfig directly with a relative-looking path. Plan resolution should
+    // normalize to an absolute File so the banner and shutdown logic do not depend on CWD.
+    QuickstartConfig c =
+        new QuickstartConfig(QuickstartConfig.DEFAULT_INSTANCE_NAME, "secret", 2181, 9995, 9999,
+            9997, 1, 0, 1, 256, Duration.ofSeconds(60), "", "", dir.getAbsolutePath());
+    QuickstartConfig.DataDirPlan plan = c.resolveDataDirPlan();
+    assertTrue(plan.path().isAbsolute(), () -> "plan path must be absolute; got " + plan.path());
+  }
+
+  @Test
+  public void constructorAcceptsDataDirAndExposesIt() {
+    QuickstartConfig c = new QuickstartConfig(QuickstartConfig.DEFAULT_INSTANCE_NAME, "secret",
+        2181, 9995, 9999, 9997, 1, 0, 1, 256, Duration.ofSeconds(60), "", "", "/var/lib/accumulo");
+    assertEquals("/var/lib/accumulo", c.dataDir());
+  }
+
+  @Test
+  public void legacyConstructorsDefaultDataDirToNull() {
+    QuickstartConfig small = new QuickstartConfig(QuickstartConfig.DEFAULT_INSTANCE_NAME, "secret",
+        2181, 9995, 9999, 9997, 1, 0, 1, 256, Duration.ofSeconds(60));
+    assertEquals(null, small.dataDir());
+    QuickstartConfig mid = new QuickstartConfig(QuickstartConfig.DEFAULT_INSTANCE_NAME, "secret",
+        2181, 9995, 9999, 9997, 1, 0, 1, 256, Duration.ofSeconds(60), "", "");
+    assertEquals(null, mid.dataDir());
   }
 }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartResumeTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/QuickstartResumeTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.minicluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * End-to-end resume round-trip exercising the Quickstart-layer CLI surface from {@code parse}
+ * through MAC startup, table mutation, MAC shutdown, and MAC restart in resume mode. Banner
+ * rendering is invoked on both runs so a regression that lets the {@code (ephemeral)} annotation
+ * slip back in is caught.
+ *
+ * <p>
+ * Scoped against the {@link QuickstartConfig#parse(String[], Map)} entry point rather than driving
+ * the {@code bin/accumulo quickstart} script: forking a subprocess from a Maven test buys nothing
+ * beyond the in-process flow, and {@code Quickstart.main}'s {@code System.exit} / shutdown-hook
+ * lifecycle is hostile to test reuse. The pieces this slice introduces - decision tree, resume
+ * dispatch, banner suppression of {@code (ephemeral)} - all live below {@code main} and are
+ * exercised in full here.
+ *
+ * <p>
+ * Post-resume user-table scan-back is verified manually rather than in this test. The MAC layer's
+ * sibling {@code MiniAccumuloClusterResumeTest.resumeRoundTripPreservesTableMetadata} documents the
+ * same constraint: Accumulo's WAL recovery loop is brittle under MAC's tserver shutdown (empty WALs
+ * around the metadata tservers can stall user-tablet assignment for minutes), so we assert
+ * table-metadata survival here and leave end-user scan verification to the manual acceptance step
+ * in the Phase 2 / Slice 4 issue.
+ */
+@SuppressFBWarnings(
+    value = {"PATH_TRAVERSAL_IN", "HARD_CODE_PASSWORD", "UNENCRYPTED_SERVER_SOCKET"},
+    justification = "test fixtures: hard-coded password is throwaway; paths come from a test "
+        + "temp dir; preflight ServerSockets are bound and immediately closed only to find free "
+        + "ports for the cluster")
+public class QuickstartResumeTest extends WithTestNames {
+
+  private static final String ROOT_PASSWORD = "resumeRoundTrip";
+  private static final String TABLE_NAME = "ingested";
+
+  private File freshDataDir() {
+    File baseDir = new File(System.getProperty("user.dir") + "/target/mini-tests/"
+        + QuickstartResumeTest.class.getName());
+    File dir = new File(baseDir, testName());
+    FileUtils.deleteQuietly(dir);
+    assertTrue(dir.mkdirs() || dir.isDirectory(),
+        "test precondition: ensured data dir " + dir + " is fresh and empty");
+    return dir;
+  }
+
+  @Test
+  @Timeout(240)
+  public void quickstartCliFlowDispatchesResumeAndPreservesTableMetadata() throws Exception {
+    File dataDir = freshDataDir();
+    int[] ports = pickFourFreePorts();
+    String[] cliArgs = quickstartArgs(dataDir, ports);
+
+    // ---- Run 1: parse, dispatch fresh, ingest, write a marker --------------------------------
+    QuickstartConfig.ParseResult parsed1 =
+        QuickstartConfig.parse(cliArgs, Map.of(QuickstartConfig.ENV_ROOT_PASSWORD, ROOT_PASSWORD));
+    assertEquals(QuickstartConfig.ParseResult.Kind.SUCCESS, parsed1.kind(),
+        () -> "parse failure: " + parsed1.message());
+    QuickstartConfig config1 = parsed1.config();
+    assertEquals(dataDir.getAbsolutePath(), config1.dataDir());
+
+    QuickstartConfig.DataDirPlan plan1 = config1.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.FRESH_AT_PATH, plan1.disposition(),
+        "first run against an empty supplied dir must dispatch fresh");
+    assertTrue(!plan1.ephemeral(),
+        "the fresh-at-path run must not be marked ephemeral so the dir survives shutdown");
+
+    MiniAccumuloConfig macConfig1 = config1.toMiniAccumuloConfig(plan1.path());
+    MiniAccumuloCluster fresh = new MiniAccumuloCluster(macConfig1);
+    fresh.start();
+    try (AccumuloClient client =
+        fresh.createAccumuloClient("root", new PasswordToken(ROOT_PASSWORD))) {
+      client.tableOperations().create(TABLE_NAME);
+      try (BatchWriter bw = client.createBatchWriter(TABLE_NAME)) {
+        Mutation m = new Mutation("row-001");
+        m.put("fam", "qual", "value-1");
+        bw.addMutation(m);
+      }
+      // Flush so the user-table data lives on disk in an rfile, independent of WAL recovery.
+      client.tableOperations().flush(TABLE_NAME, null, null, true);
+    } finally {
+      fresh.stop();
+    }
+
+    // The banner string is what the user sees on stdout; assert that the data-dir line surfaces
+    // the supplied path without the "(ephemeral)" suffix that Phase 1 (and the parent issue)
+    // explicitly call out as misleading when --data-dir is in play.
+    String banner1 = renderBanner(macConfig1, plan1, config1);
+    assertTrue(banner1.contains(dataDir.getAbsolutePath()),
+        () -> "banner must include the resolved data-dir path; got:\n" + banner1);
+    assertTrue(!banner1.contains("(ephemeral)"),
+        () -> "banner must drop the (ephemeral) tag when --data-dir is in use; got:\n" + banner1);
+
+    File marker = new File(dataDir, "mac-instance.properties");
+    assertTrue(marker.exists(), "fresh-mode MAC should have written the resume marker");
+
+    // ---- Run 2: parse again, dispatch resume, verify table metadata survived -----------------
+    QuickstartConfig.ParseResult parsed2 =
+        QuickstartConfig.parse(cliArgs, Map.of(QuickstartConfig.ENV_ROOT_PASSWORD, ROOT_PASSWORD));
+    QuickstartConfig config2 = parsed2.config();
+    QuickstartConfig.DataDirPlan plan2 = config2.resolveDataDirPlan();
+    assertEquals(QuickstartConfig.Disposition.RESUME_AT_PATH, plan2.disposition(),
+        "a populated data dir on the second run must dispatch resume");
+    assertTrue(plan2.resumeMode());
+
+    MiniAccumuloConfig macConfig2 = config2.toMiniAccumuloConfig(plan2.path());
+    macConfig2.getImpl().resume();
+    MiniAccumuloCluster resumed = new MiniAccumuloCluster(macConfig2);
+    resumed.start();
+    try (AccumuloClient client =
+        resumed.createAccumuloClient("root", new PasswordToken(ROOT_PASSWORD))) {
+      assertTrue(client.tableOperations().list().contains(TABLE_NAME),
+          TABLE_NAME + " should still exist after resume; tableOperations().list() proves the "
+              + "manager talked to the persisted metadata table on the new boot");
+    } finally {
+      resumed.stop();
+    }
+
+    String banner2 = renderBanner(macConfig2, plan2, config2);
+    assertTrue(banner2.contains(dataDir.getAbsolutePath()),
+        () -> "resume banner must also surface the supplied path; got:\n" + banner2);
+    assertTrue(!banner2.contains("(ephemeral)"),
+        () -> "resume-mode banner must also drop (ephemeral); got:\n" + banner2);
+  }
+
+  /**
+   * Render the ready banner the same way {@code Quickstart.main} does, so tests catch any drift in
+   * how {@code dataDirEphemeral} is wired across the boundary.
+   */
+  private static String renderBanner(MiniAccumuloConfig mac, QuickstartConfig.DataDirPlan plan,
+      QuickstartConfig config) {
+    return QuickstartBanner.format(
+        new QuickstartBanner.BannerInputs("quickstart", "http://localhost:" + config.monitorPort(),
+            "127.0.0.1:" + config.zooKeeperPort(), config.rootPassword(),
+            mac.getDir().getAbsolutePath(), plan.ephemeral(), config.shouldWarnInsecure()));
+  }
+
+  private static String[] quickstartArgs(File dataDir, int[] ports) {
+    return new String[] {"--data-dir", dataDir.getAbsolutePath(), "--zk-port",
+        Integer.toString(ports[0]), "--manager-port", Integer.toString(ports[1]), "--tserver-port",
+        Integer.toString(ports[2]), "--monitor-port", Integer.toString(ports[3])};
+  }
+
+  /**
+   * Allocate four free TCP ports for the cluster. ServerSocket(0) asks the OS for an unused port
+   * and immediately releases it; the small window between close and MAC's bind is the standard
+   * "free port" gamble used widely in test infrastructure. We open all four sockets at once before
+   * closing any, so the kernel does not hand us the same port four times.
+   */
+  private static int[] pickFourFreePorts() throws IOException {
+    try (ServerSocket s1 = new ServerSocket(0); ServerSocket s2 = new ServerSocket(0);
+        ServerSocket s3 = new ServerSocket(0); ServerSocket s4 = new ServerSocket(0)) {
+      return new int[] {s1.getLocalPort(), s2.getLocalPort(), s3.getLocalPort(), s4.getLocalPort()};
+    }
+  }
+}


### PR DESCRIPTION
Closes #36.

## Summary

- `bin/accumulo quickstart --data-dir <path>` is no longer refused. The Phase 1 placeholder error is gone, and the CLI now dispatches between fresh and resume modes by inspecting the supplied path's filesystem state - the decision tree from [ADR-0007 §Decision-2](https://github.com/zachradtka/newccumulo/blob/main/docs/adr/0007-mac-resume-mode-for-data-dir-persistence.md).
- `QuickstartConfig.resolveDataDirPlan()` returns a `DataDirPlan` with one of three dispositions: `EPHEMERAL_TEMP` (no flag), `FRESH_AT_PATH` (flag, path empty/nonexistent), or `RESUME_AT_PATH` (flag, path non-empty). `Quickstart.main` calls `.resume()` on the impl in the resume case, otherwise lets MAC initialize fresh.
- The banner now drops `(ephemeral)` whenever `--data-dir` is in use, on both fresh and resume runs.
- Refusal cases (foreign dir, corrupt marker, version mismatch, root-password mismatch from slices 2 & 3) propagate verbatim from MAC's `initialize()` to stderr with a non-zero exit; the Quickstart layer does not wrap or rewrite them.
- Shutdown cleanup only deletes the data directory when it was the ephemeral temp dir we created - never the user-supplied path.
- Docs (`docs/quickstart.md`) updated: persistence section rewritten, troubleshooting entries swapped for the new refusal messages.

## Test plan

- [x] `QuickstartConfigTest` adds coverage for every row of the decision tree (no flag, nonexistent, empty dir, populated dir, dir with marker, regular file at path, absolute-path normalization) plus the new `--data-dir` parsing and constructor surface. 53 tests pass.
- [x] New `QuickstartResumeTest` drives the full CLI path twice end-to-end: `parse` -> `DataDirPlan` -> MAC start -> table create + write + flush -> stop -> `parse` -> resume dispatch -> MAC start -> assert table metadata survived -> stop. Banner output is rendered the same way `Quickstart.main` does and asserted to drop `(ephemeral)` on both runs.
- [x] Full `mvn -pl minicluster -am test` is green (93 tests).
- [x] Local `mvn ... -DverifyFormat` gate passes.
- [ ] Manual verification of the issue's data-readback step: run `bin/accumulo quickstart --data-dir /tmp/foo`, populate via `accumulo shell`, Ctrl-C, run the same command, then `scan` in a new shell. Post-resume user-table scan-back is brittle under MAC's WAL recovery loop (sibling `MiniAccumuloClusterResumeTest` documents the same constraint), so it is verified manually rather than in the automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)