### PR TITLE
Fix dirty-shutdown data loss on --data-dir resume (#43)

### DIFF
--- a/docs/adr/0007-mac-resume-mode-for-data-dir-persistence.md
+++ b/docs/adr/0007-mac-resume-mode-for-data-dir-persistence.md
@@ -93,6 +93,19 @@ is delegated to Accumulo's existing machinery:
 If Accumulo's own recovery cannot cope with what is on disk, that is a bug
 in Accumulo and out of scope for this ADR.
 
+> **Durability prerequisite (issue #43).** Delegating to Accumulo's recovery
+> only works if acknowledged writes are actually on disk before the abrupt
+> stop. On a single-node `--data-dir` cluster MAC writes to the local
+> filesystem, and Hadoop's default `file://` handler (the checksummed
+> `LocalFileSystem`) buffers sub-checksum-chunk writes and ignores
+> `hsync()`/`hflush()`. An abrupt kill (power loss, `docker kill`, `kill -9`)
+> therefore left a 0-byte / header-less WAL; recovery produced an empty log,
+> the metadata mutations describing freshly written user tablets were lost, and
+> those tablets never came back online (scans hung indefinitely). MAC now
+> routes local volumes through `RawLocalFileSystem`, which performs no checksum
+> buffering and whose `hsync()` issues a real `fsync`, so acknowledged WAL
+> writes survive a dirty shutdown and the delegation above holds.
+
 ### 4. Property locking on resume
 
 On resume, MAC reads the persisted `conf/accumulo.properties` and

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -222,6 +222,21 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
       dfsUri = loadExistingHadoopConfiguration().get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY);
     } else {
       dfsUri = "file:///";
+      // When running on the local filesystem, route file:// through RawLocalFileSystem instead of
+      // the default checksummed LocalFileSystem. The checksummed stream buffers sub-checksum-chunk
+      // writes and ignores hsync()/hflush(), so write-ahead-log bytes (including the file header)
+      // can sit in process memory and be lost when a server JVM is killed abruptly -- power loss,
+      // docker kill, kill -9. The result is a 0-byte/header-less WAL on resume: recovery yields an
+      // empty log, the metadata mutations describing freshly written user tablets are gone, and
+      // those tablets never get assigned (scans hang forever). RawLocalFileSystem performs no
+      // checksum buffering and its hsync() issues a real fsync, so acknowledged WAL writes survive
+      // a dirty shutdown and --data-dir resume can replay them. Honors any caller-supplied Hadoop
+      // override so this stays a default, not a hard-coding.
+      Map<String,String> coreSite = new java.util.LinkedHashMap<>();
+      coreSite.put("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
+      coreSite.putAll(config.getHadoopConfOverrides());
+      File coreFile = new File(config.getConfDir(), "core-site.xml");
+      writeConfig(coreFile, coreSite.entrySet());
     }
 
     // Perform any modifications to the site config that need to happen

--- a/test/src/main/java/org/apache/accumulo/test/functional/QuickstartDirtyShutdownRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/QuickstartDirtyShutdownRecoveryIT.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -65,13 +64,16 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * machinery owns WAL replay.
  *
  * <p>
- * <b>Currently disabled.</b> The test was written and confirmed to fail deterministically against
- * Accumulo 2.1.5-SNAPSHOT: after SIGKILL of the quickstart and resume on the same data dir, the
- * manager re-hosts the root and metadata tablets within seconds but never attempts to assign the
- * user-table tablet (observed over 15+ minutes of polling). The bug is in Accumulo's manager-side
- * tablet-watcher loop, not in our resume plumbing, and is tracked in #43. Re-enable this test
- * (remove {@code @Disabled}) once #43 is fixed; the body of the test is exactly the assertion the
- * ADR claims and should pass without any further changes.
+ * This test failed deterministically before #43 was fixed: after SIGKILL of the quickstart and
+ * resume on the same data dir, the manager re-hosted the root and metadata tablets within seconds
+ * but never assigned the user-table tablet (observed over 15+ minutes of polling), so a scan hung
+ * forever. The root cause was not the manager tablet-watcher loop but WAL durability on the local
+ * filesystem: MAC ran {@code file://} through Hadoop's checksummed {@code LocalFileSystem}, whose
+ * output stream buffers sub-checksum-chunk writes and ignores {@code hsync()}/{@code hflush()}, so
+ * an abrupt kill left a 0-byte / header-less WAL. Recovery then produced an empty log, the metadata
+ * mutations describing the freshly written user tablet were lost, and that tablet vanished from the
+ * recovered metadata. The fix routes local volumes through {@code RawLocalFileSystem} (no checksum
+ * buffering, real {@code hsync}); see {@code MiniAccumuloClusterImpl}.
  *
  * <p>
  * Subprocess, not in-process MAC: a forked {@code bin/accumulo quickstart} mirrors what a real user
@@ -173,7 +175,6 @@ public class QuickstartDirtyShutdownRecoveryIT {
 
   @Test
   @Timeout(value = 10, unit = TimeUnit.MINUTES)
-  @Disabled("Accumulo recovery bug: user-table tablet stays UNASSIGNED on resume. Tracked in #43.")
   void dirtyShutdownThenResumePreservesUserData() throws Exception {
     int portBase = pickFreePortBase();
 


### PR DESCRIPTION
Closes #43.

## Problem

A SIGKILL / power-loss of a `bin/accumulo quickstart --data-dir <dir>` cluster followed by a resume against the same data dir left user-table tablets permanently UNASSIGNED. The manager re-hosted root and metadata within seconds, but a `scan` of the user table hung forever.

## Root cause

Not the manager tablet-watcher loop (the original hypothesis on #43), but **WAL durability on the local filesystem**.

On a single-node cluster MAC writes `file://` through Hadoop's default checksummed `LocalFileSystem`, whose output stream buffers sub-checksum-chunk writes and ignores `hsync()`/`hflush()`. An abrupt kill therefore left a 0-byte, header-less WAL on disk. This was confirmed directly: immediately after `flush -w` returned success, the WAL files were still 0 bytes.

On resume the log sort reports `Could not read header ... Not sorting` and recovers 0 mutations, so the metadata mutations describing the freshly created user tablet are lost. The tablet no longer exists in the recovered metadata, the user-level watcher never sees it, and the flushed RFile is orphaned. Root and metadata "recover" to a pre-write state and host, which is why only the user table hangs.

## Fix

For the local-filesystem case, write a `core-site.xml` that routes `file://` through `RawLocalFileSystem`. It performs no checksum buffering and its `hsync()` issues a real `fsync`, so acknowledged WAL writes (including the header) survive a dirty shutdown and resume replays them. Honors any caller-supplied Hadoop override.

## Verification

Issue reproducer, 5 SIGKILL-resume cycles each:

| Build | Result |
|---|---|
| before | 5/5 stalled >240s (scan hangs) |
| after | 5/5 recovered in ~38s, data returned |

- Re-enables `QuickstartDirtyShutdownRecoveryIT` (was `@Disabled` pending #43).
- Notes the durability prerequisite in ADR-0007 decision 3.

## Scope note

This affects every MAC-based test on local FS, not just quickstart. That is the correct layer, since the durability gap is MAC's, and `RawLocalFileSystem` is the recommended local-FS setup for Accumulo. Worth watching the broader minicluster IT suite on CI for regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)